### PR TITLE
DE-415 - User Session

### DIFF
--- a/src/abstractions/app-session/app-session-state-accessor.ts
+++ b/src/abstractions/app-session/app-session-state-accessor.ts
@@ -1,0 +1,5 @@
+import { AppSessionState } from ".";
+
+export type AppSessionStateAccessor = {
+  current: AppSessionState;
+};

--- a/src/abstractions/app-session/app-session-state-monitor.ts
+++ b/src/abstractions/app-session/app-session-state-monitor.ts
@@ -1,0 +1,6 @@
+import { AppSessionState } from ".";
+
+export interface AppSessionStateMonitor {
+  start(): void;
+  onSessionUpdate(listener: (appSessionState: AppSessionState) => void): void;
+}

--- a/src/abstractions/app-session/app-session-state.ts
+++ b/src/abstractions/app-session/app-session-state.ts
@@ -1,0 +1,14 @@
+export type AuthenticatedAppSessionState = {
+  status: "authenticated";
+  jwtToken: string;
+  unlayerUser: { id: string; email: string; signature: string };
+};
+
+export type AppSessionState =
+  | { status: "unknown" }
+  | { status: "non-authenticated" }
+  | AuthenticatedAppSessionState;
+
+export const defaultAppSessionState: AppSessionState = {
+  status: "unknown",
+};

--- a/src/abstractions/app-session/app-session-state.ts
+++ b/src/abstractions/app-session/app-session-state.ts
@@ -12,3 +12,5 @@ export type AppSessionState =
 export const defaultAppSessionState: AppSessionState = {
   status: "unknown",
 };
+
+export type AppSessionStateStatus = AppSessionState["status"];

--- a/src/abstractions/app-session/index.ts
+++ b/src/abstractions/app-session/index.ts
@@ -1,0 +1,3 @@
+export type { AppSessionState } from "./app-session-state";
+export type { AppSessionStateAccessor } from "./app-session-state-accessor";
+export { defaultAppSessionState } from "./app-session-state";

--- a/src/abstractions/app-session/index.ts
+++ b/src/abstractions/app-session/index.ts
@@ -1,3 +1,4 @@
 export type { AppSessionState } from "./app-session-state";
 export type { AppSessionStateAccessor } from "./app-session-state-accessor";
 export { defaultAppSessionState } from "./app-session-state";
+export type { AppSessionStateMonitor } from "./app-session-state-monitor";

--- a/src/abstractions/common/result-types.ts
+++ b/src/abstractions/common/result-types.ts
@@ -1,0 +1,22 @@
+export type UnexpectedError = { success: false; unexpectedError: any };
+
+export type ErrorResult<TError> =
+  | { success: false; expectedError: TError }
+  | UnexpectedError;
+
+export type Result<TResult, TError> =
+  | { success: true; value: TResult }
+  | ErrorResult<TError>;
+
+export type ResultWithoutExpectedErrors<TResult> =
+  | { success: true; value: TResult }
+  | UnexpectedError;
+
+export type EmptyResult<TError> = { success: true } | ErrorResult<TError>;
+// It does not work:
+// type EmptyResult = { success: true } | UnexpectedError;
+// Duplicate identifier 'EmptyResult'.ts(2300)
+// TODO: Research how to fix it and rename EmptyResultWithoutExpectedErrors as EmptyResult
+export type EmptyResultWithoutExpectedErrors =
+  | { success: true }
+  | UnexpectedError;

--- a/src/abstractions/configuration.ts
+++ b/src/abstractions/configuration.ts
@@ -1,3 +1,4 @@
 export type AppConfiguration = {
   readonly basename: string | undefined;
+  readonly keepAliveMilliseconds: number;
 };

--- a/src/abstractions/configuration.ts
+++ b/src/abstractions/configuration.ts
@@ -1,4 +1,5 @@
 export type AppConfiguration = {
   readonly basename: string | undefined;
   readonly keepAliveMilliseconds: number;
+  readonly loginPageUrl: string;
 };

--- a/src/abstractions/doppler-legacy-client/index.ts
+++ b/src/abstractions/doppler-legacy-client/index.ts
@@ -1,0 +1,12 @@
+import { ResultWithoutExpectedErrors } from "../common/result-types";
+
+export type DopplerLegacyUserData = {
+  jwtToken: string;
+  unlayerUser: { id: string; email: string; signature: string };
+};
+
+export interface DopplerLegacyClient {
+  getDopplerUserData: () => Promise<
+    ResultWithoutExpectedErrors<DopplerLegacyUserData>
+  >;
+}

--- a/src/abstractions/services.ts
+++ b/src/abstractions/services.ts
@@ -1,6 +1,6 @@
 import { AppConfiguration } from ".";
 import { AppConfigurationRenderer } from "./app-configuration-renderer";
-import { AppSessionStateAccessor } from "./app-session";
+import { AppSessionStateAccessor, AppSessionStateMonitor } from "./app-session";
 import { DopplerLegacyClient } from "./doppler-legacy-client";
 
 // TODO: Determine if defining this type based on a list of types possible,
@@ -12,4 +12,5 @@ export type AppServices = {
   appConfigurationRenderer: AppConfigurationRenderer;
   dopplerLegacyClient: DopplerLegacyClient;
   appSessionStateAccessor: AppSessionStateAccessor;
+  appSessionStateMonitor: AppSessionStateMonitor;
 };

--- a/src/abstractions/services.ts
+++ b/src/abstractions/services.ts
@@ -1,5 +1,6 @@
 import { AppConfiguration } from ".";
 import { AppConfigurationRenderer } from "./app-configuration-renderer";
+import { DopplerLegacyClient } from "./doppler-legacy-client";
 
 // TODO: Determine if defining this type based on a list of types possible,
 // for example based on this type:
@@ -8,4 +9,5 @@ export type AppServices = {
   window: Window;
   appConfiguration: AppConfiguration;
   appConfigurationRenderer: AppConfigurationRenderer;
+  dopplerLegacyClient: DopplerLegacyClient;
 };

--- a/src/abstractions/services.ts
+++ b/src/abstractions/services.ts
@@ -1,5 +1,6 @@
 import { AppConfiguration } from ".";
 import { AppConfigurationRenderer } from "./app-configuration-renderer";
+import { AppSessionStateAccessor } from "./app-session";
 import { DopplerLegacyClient } from "./doppler-legacy-client";
 
 // TODO: Determine if defining this type based on a list of types possible,
@@ -10,4 +11,5 @@ export type AppServices = {
   appConfiguration: AppConfiguration;
   appConfigurationRenderer: AppConfigurationRenderer;
   dopplerLegacyClient: DopplerLegacyClient;
+  appSessionStateAccessor: AppSessionStateAccessor;
 };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,6 +5,7 @@ import { Invoices } from "./invoices";
 import { Campaigns } from "./campaigns";
 import { Templates } from "./templates";
 import { ConfigurationDemo } from "./ConfigurationDemo";
+import { SessionDemo } from "./SessionDemo";
 
 export const App = () => (
   <Routes>
@@ -13,6 +14,7 @@ export const App = () => (
       <Route path="templates/:idTemplate" element={<Templates />} />
       <Route path="expenses" element={<Expenses />} />
       <Route path="invoices" element={<Invoices />} />
+      <Route path="session-demo" element={<SessionDemo />} />
       <Route path="configuration-demo" element={<ConfigurationDemo />} />
       <Route
         path="*"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,13 +5,28 @@ import { Invoices } from "./invoices";
 import { Campaigns } from "./campaigns";
 import { Templates } from "./templates";
 import { ConfigurationDemo } from "./ConfigurationDemo";
+import { RequireAuth } from "./RequireAuth";
 import { SessionDemo } from "./SessionDemo";
 
 export const App = () => (
   <Routes>
     <Route path="/" element={<Main />}>
-      <Route path="campaigns/:idCampaign" element={<Campaigns />} />
-      <Route path="templates/:idTemplate" element={<Templates />} />
+      <Route
+        path="campaigns/:idCampaign"
+        element={
+          <RequireAuth>
+            <Campaigns />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="templates/:idTemplate"
+        element={
+          <RequireAuth>
+            <Templates />
+          </RequireAuth>
+        }
+      />
       <Route path="expenses" element={<Expenses />} />
       <Route path="invoices" element={<Invoices />} />
       <Route path="session-demo" element={<SessionDemo />} />

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import {
+  AppSessionStateMonitor,
+  AppSessionState,
+  defaultAppSessionState,
+} from "../abstractions/app-session";
+import { AppSessionStateStatus } from "../abstractions/app-session/app-session-state";
+
+const AppSessionStateContext = createContext<AppSessionState>(
+  defaultAppSessionState
+);
+const AppSessionStateStatusContext = createContext<string>(
+  defaultAppSessionState.status
+);
+
+export const AppSessionStateProvider = ({
+  children,
+  appSessionStateMonitor,
+}: {
+  children: React.ReactNode;
+  appSessionStateMonitor: AppSessionStateMonitor;
+}) => {
+  const [appSessionState, setAppSessionState] = useState(
+    defaultAppSessionState
+  );
+  const [appSessionStateStatus, setAppSessionStateStatus] = useState(
+    defaultAppSessionState.status
+  );
+
+  useEffect(() => {
+    appSessionStateMonitor.onSessionUpdate((newValue) => {
+      setAppSessionState(newValue);
+      setAppSessionStateStatus(newValue.status);
+    });
+  }, []);
+
+  return (
+    <AppSessionStateContext.Provider value={appSessionState}>
+      <AppSessionStateStatusContext.Provider value={appSessionStateStatus}>
+        {children}
+      </AppSessionStateStatusContext.Provider>
+    </AppSessionStateContext.Provider>
+  );
+};
+
+export const useAppSessionState = () => useContext(AppSessionStateContext);
+export const useAppSessionStateStatus = () =>
+  useContext(AppSessionStateStatusContext) as AppSessionStateStatus;

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -6,10 +6,10 @@ import {
 } from "../abstractions/app-session";
 import { AppSessionStateStatus } from "../abstractions/app-session/app-session-state";
 
-const AppSessionStateContext = createContext<AppSessionState>(
+export const AppSessionStateContext = createContext<AppSessionState>(
   defaultAppSessionState
 );
-const AppSessionStateStatusContext = createContext<string>(
+export const AppSessionStateStatusContext = createContext<string>(
   defaultAppSessionState.status
 );
 

--- a/src/components/NavigateToExternalUrl.tsx
+++ b/src/components/NavigateToExternalUrl.tsx
@@ -1,0 +1,20 @@
+import { useLayoutEffect } from "react";
+import { AppServices } from "../abstractions";
+import { InjectAppServices } from "./AppServicesContext";
+
+export const NavigateToExternalUrl = InjectAppServices(
+  ({
+    to,
+    appServices: {
+      window: { location },
+    },
+  }: {
+    to: string;
+    appServices: AppServices;
+  }) => {
+    useLayoutEffect(() => {
+      location.href = to;
+    }, [to, location]);
+    return <></>;
+  }
+);

--- a/src/components/RequireAuth.test.tsx
+++ b/src/components/RequireAuth.test.tsx
@@ -1,0 +1,78 @@
+import { screen, render } from "@testing-library/react";
+import { AppServices } from "../abstractions";
+import { AppServicesProvider } from "./AppServicesContext";
+import { AppSessionStateStatusContext } from "./AppSessionStateContext";
+import { RequireAuth } from "./RequireAuth";
+
+describe(RequireAuth.name, () => {
+  it("should render a waiting message when session status is unknown", () => {
+    // Arrange
+    const expectedText = "Loading...";
+    const privateText = "ULTRA TOP SECRET";
+    const appServices = {
+      appConfiguration: { loginPageUrl: "/login" },
+    } as AppServices;
+
+    // Act
+    render(
+      <AppSessionStateStatusContext.Provider value="unknown">
+        <RequireAuth appServices={appServices}>
+          <p>{privateText}</p>
+        </RequireAuth>
+      </AppSessionStateStatusContext.Provider>
+    );
+    // Assert
+    const expectedTextEl = screen.queryByText(expectedText);
+    expect(expectedTextEl).toBeInTheDocument();
+    const privateTextEl = screen.queryByText(privateText);
+    expect(privateTextEl).not.toBeInTheDocument();
+  });
+
+  it("should render the original element when session status is authenticated", () => {
+    // Arrange
+    const expectedText = "Authorized!!!";
+    const appServices = {
+      appConfiguration: { loginPageUrl: "/login" },
+    } as AppServices;
+
+    // Act
+    render(
+      <AppSessionStateStatusContext.Provider value="authenticated">
+        <RequireAuth appServices={appServices}>
+          <p>{expectedText}</p>
+        </RequireAuth>
+      </AppSessionStateStatusContext.Provider>
+    );
+
+    // Assert
+    const expectedTextEl = screen.queryByText(expectedText);
+    expect(expectedTextEl).toBeInTheDocument();
+  });
+
+  it("should redirect to the login page when session status is non-authenticated", () => {
+    // Arrange
+    const loginUrl = "/my-login";
+    const privateText = "ULTRA TOP SECRET";
+    const windowDouble = { location: { href: "" } } as unknown as Window;
+    const appServices = {
+      window: windowDouble,
+      appConfiguration: { loginPageUrl: loginUrl },
+    } as AppServices;
+
+    // Act
+    render(
+      <AppServicesProvider appServices={appServices}>
+        <AppSessionStateStatusContext.Provider value="non-authenticated">
+          <RequireAuth>
+            <p>{privateText}</p>
+          </RequireAuth>
+        </AppSessionStateStatusContext.Provider>
+      </AppServicesProvider>
+    );
+
+    // Assert
+    const privateTextEl = screen.queryByText(privateText);
+    expect(privateTextEl).not.toBeInTheDocument();
+    expect(windowDouble.location.href).toBe(loginUrl);
+  });
+});

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,26 @@
+import { AppServices } from "../abstractions";
+import { InjectAppServices } from "./AppServicesContext";
+import { useAppSessionStateStatus } from "./AppSessionStateContext";
+import { NavigateToExternalUrl } from "./NavigateToExternalUrl";
+
+export const RequireAuth = InjectAppServices(
+  ({
+    children,
+    appServices: {
+      appConfiguration: { loginPageUrl },
+    },
+  }: {
+    children: JSX.Element;
+    appServices: AppServices;
+  }) => {
+    const appSessionStateStatus = useAppSessionStateStatus();
+
+    return appSessionStateStatus === "unknown" ? (
+      <div>Loading...</div>
+    ) : appSessionStateStatus !== "authenticated" ? (
+      <NavigateToExternalUrl to={loginPageUrl} />
+    ) : (
+      children
+    );
+  }
+);

--- a/src/components/SessionDemo.tsx
+++ b/src/components/SessionDemo.tsx
@@ -1,0 +1,30 @@
+import { AppServices } from "../abstractions";
+import { InjectAppServices } from "./AppServicesContext";
+import { useAppSessionStateStatus } from "./AppSessionStateContext";
+
+export const SessionDemo = InjectAppServices(
+  ({
+    appServices: { appSessionStateAccessor },
+  }: {
+    appServices: AppServices;
+  }) => {
+    const sessionStateStatus = useAppSessionStateStatus();
+    return (
+      <>
+        <code>
+          <pre>
+            SessionStateStatus from context: {sessionStateStatus}
+            <br />
+            SessionState from AppServices:{" "}
+            {JSON.stringify(appSessionStateAccessor.current)}
+          </pre>
+        </code>
+        <p>
+          SessionState from AppServices could be not rendered updated because
+          React does not know when it changes. If we need updated in a React
+          component, we can use <code>useAppSessionState()</code>
+        </p>
+      </>
+    );
+  }
+);

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -1,4 +1,5 @@
 import { AppConfiguration, AppServices } from "./abstractions";
+import { defaultAppSessionState } from "./abstractions/app-session/app-session-state";
 import { AppConfigurationRendererImplementation } from "./implementations/app-configuration-renderer";
 import { DummyDopplerLegacyClient } from "./implementations/dummies/doppler-legacy-client";
 import {
@@ -15,12 +16,17 @@ export const configureApp = (
     ...customConfiguration,
   };
 
+  const appSessionStateWrapper = {
+    current: defaultAppSessionState,
+  };
+
   const factories: ServicesFactories = {
     windowFactory: () => window,
     appConfigurationFactory: () => appConfiguration,
     appConfigurationRendererFactory: (appServices: AppServices) =>
       new AppConfigurationRendererImplementation(appServices),
     dopplerLegacyClientFactory: () => new DummyDopplerLegacyClient(),
+    appSessionStateAccessorFactory: () => appSessionStateWrapper,
   };
 
   const appServices = new SingletonLazyAppServicesContainer(factories);

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -1,6 +1,10 @@
 import { AppConfiguration, AppServices } from "./abstractions";
 import { defaultAppSessionState } from "./abstractions/app-session/app-session-state";
 import { AppConfigurationRendererImplementation } from "./implementations/app-configuration-renderer";
+import {
+  //
+  PullingAppSessionStateMonitor,
+} from "./implementations/app-session/pulling-app-session-state-monitor";
 import { DummyDopplerLegacyClient } from "./implementations/dummies/doppler-legacy-client";
 import {
   ServicesFactories,
@@ -27,6 +31,11 @@ export const configureApp = (
       new AppConfigurationRendererImplementation(appServices),
     dopplerLegacyClientFactory: () => new DummyDopplerLegacyClient(),
     appSessionStateAccessorFactory: () => appSessionStateWrapper,
+    appSessionStateMonitorFactory: (appServices: AppServices) =>
+      new PullingAppSessionStateMonitor({
+        appSessionStateWrapper,
+        appServices,
+      }),
   };
 
   const appServices = new SingletonLazyAppServicesContainer(factories);

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -1,5 +1,6 @@
 import { AppConfiguration, AppServices } from "./abstractions";
 import { AppConfigurationRendererImplementation } from "./implementations/app-configuration-renderer";
+import { DummyDopplerLegacyClient } from "./implementations/dummies/doppler-legacy-client";
 import {
   ServicesFactories,
   SingletonLazyAppServicesContainer,
@@ -19,6 +20,7 @@ export const configureApp = (
     appConfigurationFactory: () => appConfiguration,
     appConfigurationRendererFactory: (appServices: AppServices) =>
       new AppConfigurationRendererImplementation(appServices),
+    dopplerLegacyClientFactory: () => new DummyDopplerLegacyClient(),
   };
 
   const appServices = new SingletonLazyAppServicesContainer(factories);

--- a/src/default-configuration.ts
+++ b/src/default-configuration.ts
@@ -2,4 +2,5 @@ import { AppConfiguration } from "./abstractions";
 
 export const defaultAppConfiguration: AppConfiguration = {
   basename: undefined,
+  keepAliveMilliseconds: 300000,
 };

--- a/src/default-configuration.ts
+++ b/src/default-configuration.ts
@@ -3,4 +3,7 @@ import { AppConfiguration } from "./abstractions";
 export const defaultAppConfiguration: AppConfiguration = {
   basename: undefined,
   keepAliveMilliseconds: 300000,
+  // Original WebApp shares the same domain than Editors WebApp. So, it is not
+  // necessary to specify the domain, and the path is shared across environments
+  loginPageUrl: "/login",
 };

--- a/src/implementations/SingletonLazyAppServicesContainer.ts
+++ b/src/implementations/SingletonLazyAppServicesContainer.ts
@@ -35,4 +35,8 @@ export class SingletonLazyAppServicesContainer implements AppServices {
   get appConfigurationRenderer() {
     return this.singleton("appConfigurationRenderer");
   }
+
+  get dopplerLegacyClient() {
+    return this.singleton("dopplerLegacyClient");
+  }
 }

--- a/src/implementations/SingletonLazyAppServicesContainer.ts
+++ b/src/implementations/SingletonLazyAppServicesContainer.ts
@@ -43,4 +43,8 @@ export class SingletonLazyAppServicesContainer implements AppServices {
   get appSessionStateAccessor() {
     return this.singleton("appSessionStateAccessor");
   }
+
+  get appSessionStateMonitor() {
+    return this.singleton("appSessionStateMonitor");
+  }
 }

--- a/src/implementations/SingletonLazyAppServicesContainer.ts
+++ b/src/implementations/SingletonLazyAppServicesContainer.ts
@@ -39,4 +39,8 @@ export class SingletonLazyAppServicesContainer implements AppServices {
   get dopplerLegacyClient() {
     return this.singleton("dopplerLegacyClient");
   }
+
+  get appSessionStateAccessor() {
+    return this.singleton("appSessionStateAccessor");
+  }
 }

--- a/src/implementations/app-session/pulling-app-session-state-monitor.ts
+++ b/src/implementations/app-session/pulling-app-session-state-monitor.ts
@@ -1,0 +1,58 @@
+import { EventEmitter } from "events";
+import { AppServices } from "../../abstractions";
+import {
+  AppSessionState,
+  AppSessionStateMonitor,
+  defaultAppSessionState,
+} from "../../abstractions/app-session";
+
+const SESSION_STATE_UPDATE = Symbol("SESSION_STATE_UPDATE");
+
+export class PullingAppSessionStateMonitor implements AppSessionStateMonitor {
+  private readonly _appSessionStateWrapper;
+  private readonly _window;
+  private readonly _dopplerLegacyClient;
+  private readonly _eventEmitter = new EventEmitter();
+  private readonly _keepAliveMilliseconds;
+
+  constructor({
+    appSessionStateWrapper,
+    appServices: {
+      window,
+      dopplerLegacyClient,
+      appConfiguration: { keepAliveMilliseconds },
+    },
+  }: {
+    appSessionStateWrapper: { current: AppSessionState };
+    appServices: AppServices;
+  }) {
+    this._appSessionStateWrapper = appSessionStateWrapper;
+    this._window = window;
+    this._dopplerLegacyClient = dopplerLegacyClient;
+    this._keepAliveMilliseconds = keepAliveMilliseconds;
+  }
+
+  private updateAndEmit(appSessionState: AppSessionState): void {
+    this._appSessionStateWrapper.current = appSessionState;
+    this._eventEmitter.emit(SESSION_STATE_UPDATE, appSessionState);
+  }
+
+  private async fetchDopplerUserData(): Promise<AppSessionState> {
+    const result = await this._dopplerLegacyClient.getDopplerUserData();
+    return result.success
+      ? { status: "authenticated", ...result.value }
+      : { status: "non-authenticated" };
+  }
+
+  async start(): Promise<void> {
+    this.updateAndEmit(defaultAppSessionState);
+    this._window.setInterval(async () => {
+      this.updateAndEmit(await this.fetchDopplerUserData());
+    }, this._keepAliveMilliseconds);
+    this.updateAndEmit(await this.fetchDopplerUserData());
+  }
+
+  onSessionUpdate(listener: (appSessionState: AppSessionState) => void): void {
+    this._eventEmitter.on(SESSION_STATE_UPDATE, listener);
+  }
+}

--- a/src/implementations/dummies/doppler-legacy-client.tsx
+++ b/src/implementations/dummies/doppler-legacy-client.tsx
@@ -1,0 +1,37 @@
+import { timeout } from "../../utils";
+import {
+  DopplerLegacyClient,
+  DopplerLegacyUserData,
+} from "../../abstractions/doppler-legacy-client";
+import { ResultWithoutExpectedErrors } from "../../abstractions/common/result-types";
+
+let counter = 0;
+
+export class DummyDopplerLegacyClient implements DopplerLegacyClient {
+  public getDopplerUserData: () => Promise<
+    ResultWithoutExpectedErrors<DopplerLegacyUserData>
+  > = async () => {
+    try {
+      console.log("Begin getDopplerUserData...");
+      await timeout(3000);
+      const result: ResultWithoutExpectedErrors<DopplerLegacyUserData> = {
+        success: true,
+        value: {
+          jwtToken: `jwtToken-${counter++}`,
+          unlayerUser: {
+            id: "demo-123",
+            email: "test@test.com",
+            signature: "unlayer-signature",
+          },
+        },
+      };
+      console.log("End getDopplerUserData", { result });
+      return result;
+    } catch (e) {
+      return {
+        success: false,
+        unexpectedError: e,
+      };
+    }
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { App } from "./components/App";
 import { reportWebVitals } from "./reportWebVitals";
 import { configureApp } from "./composition-root";
 import { AppServicesProvider } from "./components/AppServicesContext";
+import { AppSessionStateProvider } from "./components/AppSessionStateContext";
 
 const customConfiguration =
   (window as any)["editors-webapp-configuration"] || {};
@@ -23,9 +24,11 @@ appSessionStateMonitor.start();
 render(
   <StrictMode>
     <AppServicesProvider appServices={appServices}>
-      <BrowserRouter basename={appServices.appConfiguration.basename}>
-        <App />
-      </BrowserRouter>
+      <AppSessionStateProvider appSessionStateMonitor={appSessionStateMonitor}>
+        <BrowserRouter basename={appServices.appConfiguration.basename}>
+          <App />
+        </BrowserRouter>
+      </AppSessionStateProvider>
     </AppServicesProvider>
   </StrictMode>,
   document.getElementById("root")

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,9 @@ if ((window as any).basename) {
 
 const appServices = configureApp(customConfiguration);
 
+const appSessionStateMonitor = appServices.appSessionStateMonitor;
+appSessionStateMonitor.start();
+
 render(
   <StrictMode>
     <AppServicesProvider appServices={appServices}>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,2 @@
+export const timeout = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Hi @Cromeror, @maurocardinali, @jcamposmk, @ck-makingsense, @leoslopez and team!

We are following the same approach as the _"Original" WebApp_: we are pulling to `GetUserData` and, based on its response, we update our internal representation of the session.

When a component depends on an authenticated session and the session status is _non-authenticated_, it redirects to the log-in page:

![2021-12-22_13-44-15 (1)](https://user-images.githubusercontent.com/1157864/147126827-9bd36111-60a3-485c-9279-0ac01e921bf2.gif)

When the status is _unknown_, it waits, and when the status is _authenticated_, it simply works:

![2021-12-22_12-33-58 (1)](https://user-images.githubusercontent.com/1157864/147126975-42498296-e478-45b6-a5b5-3977ad53a824.gif)

We have also applied an improvement over _"Original" WebApp_ behavior, when the session data is not important, only the status, we have a hook only for the status, so, when the session data is updated, but the status is the same, it avoids unnecessary renderings:

![2021-12-22_12-17-40 (1)](https://user-images.githubusercontent.com/1157864/147127410-eef0e09c-cf06-4f8f-8b77-236ccbae5f52.gif)

See `SessionDemo` component for more details.

The next steps are:

* Implement real client for `GetUserData` [DE-425](https://makingsense.atlassian.net/browse/DE-425)

* Use the session information for Unlayer Editor [DE-426](https://makingsense.atlassian.net/browse/DE-426)

