### PR TITLE
chore: allow to parse version and nocache from querystring in demo page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -15,20 +15,30 @@
     <div id="root"></div>
     <script src="https://cdn.fromdoppler.com/loader/v1/loader.js"></script>
     <script type="text/javascript">
-      const versions = {
-        // Build of a random pull request
-        pr: "pr-2",
-        // Build of the INT branch
-        int: "INT",
-        // Build of the main branch
-        main: "main",
-        // Build of a final version
-        v1: "v1",
-      };
+      const versionParamRegex = new RegExp(
+        "\\?(?:.+&)*" +
+          "ew_version=((?:(?:main)|(?:INT)|(?:pr-\\d+)|(?:v\\d+(?:\\.\\d+){0,2})))" +
+          "(?:-([a-f\\d]{40}))?" +
+          "(?:&.*)?$"
+      );
+      const versionParamRegexResult = location.href.match(versionParamRegex);
+      const defaultVersion = "main";
+      const version = versionParamRegexResult
+        ? versionParamRegexResult[1]
+        : defaultVersion;
+      const defaultCommitId = "";
+      const commitId =
+        (versionParamRegexResult && versionParamRegexResult[2]) ||
+        defaultCommitId;
 
-      const version = versions.main; // 👈 choose a version
-      const avoidCache = true; // 👈 modify
-      const commitId = ""; // 👈 define commit ID to a hard cache invalidation
+      const avoidCacheParamRegex =
+        /\?(?:.+&)*ew_nocache=((?:true)|(?:false))(?:&.*)?$/;
+      const avoidCacheParamRegexResult =
+        location.href.match(avoidCacheParamRegex);
+      const avoidCacheDefault = true;
+      const avoidCache = avoidCacheParamRegexResult
+        ? avoidCacheParamRegexResult[1] == "true"
+        : avoidCacheDefault;
 
       const cdnBaseUrl = "https://cdn.fromdoppler.com";
       const pkgName = "editors-webapp";


### PR DESCRIPTION
Related to https://github.com/MakingSense/doppler-swarm/pull/589 but in our local demo index.html file.

Some examples:

![image](https://user-images.githubusercontent.com/1157864/147927389-2043ad92-f7bb-42fc-b21b-756ea3a93877.png)

![image](https://user-images.githubusercontent.com/1157864/147927403-eb6983fb-504a-436c-b425-cd0d2550f317.png)

![image](https://user-images.githubusercontent.com/1157864/147927415-a05fe2cd-5972-4b46-b9a4-943314241087.png)

![image](https://user-images.githubusercontent.com/1157864/147927424-9eea1966-f300-4fa7-8e3c-9b0aea7a59b3.png)
