### PR TITLE
chore: remove wrong email field from unlayerUser

### DIFF
--- a/src/abstractions/app-session/app-session-state.ts
+++ b/src/abstractions/app-session/app-session-state.ts
@@ -1,7 +1,7 @@
 export type AuthenticatedAppSessionState = {
   status: "authenticated";
   jwtToken: string;
-  unlayerUser: { id: string; email: string; signature: string };
+  unlayerUser: { id: string; signature: string };
 };
 
 export type AppSessionState =

--- a/src/abstractions/doppler-legacy-client/index.ts
+++ b/src/abstractions/doppler-legacy-client/index.ts
@@ -2,7 +2,7 @@ import { ResultWithoutExpectedErrors } from "../common/result-types";
 
 export type DopplerLegacyUserData = {
   jwtToken: string;
-  unlayerUser: { id: string; email: string; signature: string };
+  unlayerUser: { id: string; signature: string };
 };
 
 export interface DopplerLegacyClient {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -29,12 +29,11 @@ export const Editor = ({ design }: { design?: Design }) => {
     return <p>This component requires an authenticated session</p>;
   }
 
-  const { id, email, signature } = appSessionStateAccessor.current.unlayerUser;
+  const { id, signature } = appSessionStateAccessor.current.unlayerUser;
 
   const user: ExtendedUnlayerUser = {
     // Ugly patch because Unlayer types does not accept string as id
     id: id as unknown as number,
-    email,
     signature,
   };
 

--- a/src/implementations/dummies/doppler-legacy-client.tsx
+++ b/src/implementations/dummies/doppler-legacy-client.tsx
@@ -20,7 +20,6 @@ export class DummyDopplerLegacyClient implements DopplerLegacyClient {
           jwtToken: `jwtToken-${counter++}`,
           unlayerUser: {
             id: "local_105690",
-            email: "test@test.com",
             signature:
               "c3a76d3bd1d1216fb538c22cc970db4bc31d09db091c861f7d10b0ced3a4348b",
           },


### PR DESCRIPTION
We will not use the email field in Unlayer's user model.