### PR TITLE
Rename components

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,8 +2,8 @@ import { Routes, Route } from "react-router-dom";
 import { Main } from "./Main";
 import { Expenses } from "./expenses";
 import { Invoices } from "./invoices";
-import { Campaigns } from "./campaigns";
-import { Templates } from "./templates";
+import { Campaign } from "./Campaign";
+import { Template } from "./Template";
 import { ConfigurationDemo } from "./ConfigurationDemo";
 import { RequireAuth } from "./RequireAuth";
 import { SessionDemo } from "./SessionDemo";
@@ -15,7 +15,7 @@ export const App = () => (
         path="campaigns/:idCampaign"
         element={
           <RequireAuth>
-            <Campaigns />
+            <Campaign />
           </RequireAuth>
         }
       />
@@ -23,7 +23,7 @@ export const App = () => (
         path="templates/:idTemplate"
         element={
           <RequireAuth>
-            <Templates />
+            <Template />
           </RequireAuth>
         }
       />

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -1,0 +1,5 @@
+import { Editor } from "./Editor";
+
+export const Campaign = () => {
+  return <Editor></Editor>;
+};

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -1,0 +1,5 @@
+import { Editor } from "./Editor";
+
+export const Template = () => {
+  return <Editor></Editor>;
+};

--- a/src/components/campaigns.tsx
+++ b/src/components/campaigns.tsx
@@ -1,5 +1,0 @@
-import { Editor } from "../components/Editor";
-
-export const Campaigns = () => {
-  return <Editor></Editor>;
-};

--- a/src/components/templates.tsx
+++ b/src/components/templates.tsx
@@ -1,5 +1,0 @@
-import { Editor } from "../components/Editor";
-
-export const Templates = () => {
-  return <Editor></Editor>;
-};


### PR DESCRIPTION
I have renamed `Campaigns` and `Templates` components as `Campaign` and `Template` because they represent the edition of a particular campaign or template, not a list of them.

I also made the components filenames PascalCase. I do not have a strong opinion on this, but it seems to be the most common convention, right?