### PR TITLE
DE-430 - Allow dummy behavior

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -40,6 +40,15 @@
         ? avoidCacheParamRegexResult[1] == "true"
         : avoidCacheDefault;
 
+      const useDummiesParamRegex =
+        /\?(?:.+&)*ew_dummy=((?:true)|(?:false))(?:&.*)?$/;
+      const useDummiesParamRegexResult =
+        location.href.match(useDummiesParamRegex);
+      const useDummiesDefault = false;
+      const useDummies = useDummiesParamRegexResult
+        ? useDummiesParamRegexResult[1] == "true"
+        : useDummiesDefault;
+
       const cdnBaseUrl = "https://cdn.fromdoppler.com";
       const pkgName = "editors-webapp";
       const scriptUrl = `${cdnBaseUrl}/${pkgName}/asset-manifest-${version}${
@@ -50,6 +59,7 @@
 
       window["editors-webapp-configuration"] = {
         basename: "editors",
+        useDummies,
       };
 
       new AssetServices().load(scriptUrl);

--- a/src/abstractions/configuration.ts
+++ b/src/abstractions/configuration.ts
@@ -6,4 +6,5 @@ export type AppConfiguration = {
   readonly unlayerEditorManifestUrl: string;
   readonly loaderUrl: string;
   readonly dopplerLegacyBaseUrl: string;
+  readonly useDummies: boolean;
 };

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -12,6 +12,7 @@ import {
 } from "./implementations/SingletonLazyAppServicesContainer";
 import { defaultAppConfiguration } from "./default-configuration";
 import { DopplerLegacyClientImpl } from "./implementations/DopplerLegacyClientImpl";
+import { DummyDopplerLegacyClient } from "./implementations/dummies/doppler-legacy-client";
 
 export const configureApp = (
   customConfiguration: Partial<AppConfiguration>
@@ -25,7 +26,7 @@ export const configureApp = (
     current: defaultAppSessionState,
   };
 
-  const factories: ServicesFactories = {
+  const realFactories: ServicesFactories = {
     windowFactory: () => window,
     axiosStaticFactory: () => axios,
     appConfigurationFactory: () => appConfiguration,
@@ -43,6 +44,14 @@ export const configureApp = (
         appServices,
       }),
   };
+
+  const dummyFactories: Partial<ServicesFactories> = {
+    dopplerLegacyClientFactory: () => new DummyDopplerLegacyClient(),
+  };
+
+  const factories = appConfiguration.useDummies
+    ? { ...realFactories, ...dummyFactories }
+    : realFactories;
 
   const appServices = new SingletonLazyAppServicesContainer(factories);
 

--- a/src/default-configuration.ts
+++ b/src/default-configuration.ts
@@ -11,4 +11,5 @@ export const defaultAppConfiguration: AppConfiguration = {
   loaderUrl: "https://cdn.fromdoppler.com/loader/v1/loader.js",
   unlayerProjectId: 32092,
   dopplerLegacyBaseUrl: "https://appint.fromdoppler.net",
+  useDummies: true,
 };


### PR DESCRIPTION
Hi team! 

I think that it will be really useful because it will allow us to work without the backend during development and also to test things in other environments.

Related to https://github.com/MakingSense/doppler-swarm/pull/590

If you add the query string ew_dummy=true it will use dummy versions of the backend adapters.

In your local environment, you could edit the default configuration, or even we can make it dummy by default 🤔

Could you review it?