### PR TITLE
fix: render campaign unexpected error as string

### DIFF
--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -50,7 +50,7 @@ export const Campaign = () => {
   if (!state.loading && !state.design) {
     return (
       <div data-testid={errorMessageTestId}>
-        Unexpected Error: {state.error}
+        Unexpected Error: <pre>{JSON.stringify(state.error)}</pre>
       </div>
     );
   }


### PR DESCRIPTION
I was trying to render the error object as it was, but the error is something like: 

```
Uncaught Error: Objects are not valid as a React child (found: Error: X). If you meant to render a collection of children, use an array instead.
```

Now, I am serializing it before rendering.

Obviously, it is something temporal, in the future, these kinds of errors should be rendered in a nicer way.

I did not change the tests, because the test `should show loading and then error when getCampaignContent is not successful` is already covering this scenario, but it seems that in the reality, the behavior is different from the test.