### PR TITLE
refactor: improve result representation types

### DIFF
--- a/src/abstractions/common/result-types.ts
+++ b/src/abstractions/common/result-types.ts
@@ -1,22 +1,14 @@
-export type UnexpectedError = { success: false; unexpectedError: any };
+type SuccessResult<TResult> = TResult extends void
+  ? { success: true }
+  : { success: true; value: TResult };
 
-export type ErrorResult<TError> =
-  | { success: false; expectedError: TError }
-  | UnexpectedError;
+type UnexpectedError = { success: false; unexpectedError: any };
 
-export type Result<TResult, TError> =
-  | { success: true; value: TResult }
-  | ErrorResult<TError>;
+type ErrorResult<TExpectedError> = { success: false; error: TExpectedError };
 
-export type ResultWithoutExpectedErrors<TResult> =
-  | { success: true; value: TResult }
-  | UnexpectedError;
-
-export type EmptyResult<TError> = { success: true } | ErrorResult<TError>;
-// It does not work:
-// type EmptyResult = { success: true } | UnexpectedError;
-// Duplicate identifier 'EmptyResult'.ts(2300)
-// TODO: Research how to fix it and rename EmptyResultWithoutExpectedErrors as EmptyResult
-export type EmptyResultWithoutExpectedErrors =
-  | { success: true }
-  | UnexpectedError;
+export type Result<
+  TResult = void,
+  TExpectedError = void
+> = TExpectedError extends void
+  ? SuccessResult<TResult> | UnexpectedError
+  : SuccessResult<TResult> | ErrorResult<TExpectedError> | UnexpectedError;

--- a/src/abstractions/doppler-legacy-client/index.ts
+++ b/src/abstractions/doppler-legacy-client/index.ts
@@ -1,4 +1,4 @@
-import { ResultWithoutExpectedErrors } from "../common/result-types";
+import { Result } from "../common/result-types";
 
 export type DopplerLegacyUserData = {
   jwtToken: string;
@@ -15,7 +15,5 @@ export type DopplerLegacyUserData = {
 };
 
 export interface DopplerLegacyClient {
-  getDopplerUserData: () => Promise<
-    ResultWithoutExpectedErrors<DopplerLegacyUserData>
-  >;
+  getDopplerUserData: () => Promise<Result<DopplerLegacyUserData>>;
 }

--- a/src/abstractions/html-editor-api-client/index.ts
+++ b/src/abstractions/html-editor-api-client/index.ts
@@ -1,8 +1,6 @@
 import { Design } from "react-email-editor";
-import { ResultWithoutExpectedErrors } from "../common/result-types";
+import { Result } from "../common/result-types";
 
 export interface HtmlEditorApiClient {
-  getCampaignContent: (
-    campaignId: string
-  ) => Promise<ResultWithoutExpectedErrors<Design>>;
+  getCampaignContent: (campaignId: string) => Promise<Result<Design>>;
 }

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from "react";
 import { Design } from "react-email-editor";
 import { useParams } from "react-router-dom";
-import { UnexpectedError } from "../abstractions/common/result-types";
 import { Editor } from "../components/Editor";
 import { useAppServices } from "./AppServicesContext";
 
 type LoadingDesignState =
   | { loading: true; error: null; design: null }
-  | { error: UnexpectedError; loading: false; design: null }
+  | { error: any; loading: false; design: null }
   | { design: Design; loading: false; error: null };
 
 export const loadingMessageTestId = "loading-message";
@@ -27,7 +26,7 @@ export const Campaign = () => {
     const loadDesign = async () => {
       if (!idCampaign) {
         setState({
-          error: { success: false, unexpectedError: "Missing idCampaign" },
+          error: "Missing idCampaign",
           loading: false,
           design: null,
         });

--- a/src/implementations/DopplerLegacyClientImpl.ts
+++ b/src/implementations/DopplerLegacyClientImpl.ts
@@ -2,7 +2,7 @@ import {
   DopplerLegacyClient,
   DopplerLegacyUserData,
 } from "../abstractions/doppler-legacy-client";
-import { ResultWithoutExpectedErrors } from "../abstractions/common/result-types";
+import { Result } from "../abstractions/common/result-types";
 import { AxiosInstance, AxiosResponse, AxiosStatic } from "axios";
 import { AppConfiguration } from "../abstractions";
 
@@ -22,9 +22,7 @@ export class DopplerLegacyClientImpl implements DopplerLegacyClient {
     });
   }
 
-  async getDopplerUserData(): Promise<
-    ResultWithoutExpectedErrors<DopplerLegacyUserData>
-  > {
+  async getDopplerUserData(): Promise<Result<DopplerLegacyUserData>> {
     try {
       const axiosResponse: AxiosResponse<DopplerLegacyUserData> =
         await this.axios.get("/WebApp/GetUserData");

--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -1,4 +1,4 @@
-import { ResultWithoutExpectedErrors } from "../abstractions/common/result-types";
+import { Result } from "../abstractions/common/result-types";
 import { AppConfiguration } from "../abstractions";
 import { HtmlEditorApiClient } from "../abstractions/html-editor-api-client";
 import { Design } from "react-email-editor";
@@ -44,9 +44,7 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
     });
   }
 
-  async getCampaignContent(
-    campaignId: string
-  ): Promise<ResultWithoutExpectedErrors<Design>> {
+  async getCampaignContent(campaignId: string): Promise<Result<Design>> {
     try {
       const response = await this.GET<any>(
         `/campaigns/${campaignId}/content/design`

--- a/src/implementations/dummies/doppler-legacy-client.tsx
+++ b/src/implementations/dummies/doppler-legacy-client.tsx
@@ -3,44 +3,43 @@ import {
   DopplerLegacyClient,
   DopplerLegacyUserData,
 } from "../../abstractions/doppler-legacy-client";
-import { ResultWithoutExpectedErrors } from "../../abstractions/common/result-types";
+import { Result } from "../../abstractions/common/result-types";
 
 let counter = 0;
 
 export class DummyDopplerLegacyClient implements DopplerLegacyClient {
-  public getDopplerUserData: () => Promise<
-    ResultWithoutExpectedErrors<DopplerLegacyUserData>
-  > = async () => {
-    try {
-      console.log("Begin getDopplerUserData...");
-      await timeout(3000);
-      const result: ResultWithoutExpectedErrors<DopplerLegacyUserData> = {
-        success: true,
-        value: {
-          jwtToken: `jwtToken-${counter++}`,
-          user: {
-            email: "test@test.com",
-            fullname: "Juan Perez",
-            lang: "es",
-            avatar: {
-              text: "JP",
-              color: "#99CFB8",
+  public getDopplerUserData: () => Promise<Result<DopplerLegacyUserData>> =
+    async () => {
+      try {
+        console.log("Begin getDopplerUserData...");
+        await timeout(3000);
+        const result: Result<DopplerLegacyUserData> = {
+          success: true,
+          value: {
+            jwtToken: `jwtToken-${counter++}`,
+            user: {
+              email: "test@test.com",
+              fullname: "Juan Perez",
+              lang: "es",
+              avatar: {
+                text: "JP",
+                color: "#99CFB8",
+              },
+            },
+            unlayerUser: {
+              id: "local_105690",
+              signature:
+                "c3a76d3bd1d1216fb538c22cc970db4bc31d09db091c861f7d10b0ced3a4348b",
             },
           },
-          unlayerUser: {
-            id: "local_105690",
-            signature:
-              "c3a76d3bd1d1216fb538c22cc970db4bc31d09db091c861f7d10b0ced3a4348b",
-          },
-        },
-      };
-      console.log("End getDopplerUserData", { result });
-      return result;
-    } catch (e) {
-      return {
-        success: false,
-        unexpectedError: e,
-      };
-    }
-  };
+        };
+        console.log("End getDopplerUserData", { result });
+        return result;
+      } catch (e) {
+        return {
+          success: false,
+          unexpectedError: e,
+        };
+      }
+    };
 }

--- a/src/implementations/dummies/html-editor-api-client.tsx
+++ b/src/implementations/dummies/html-editor-api-client.tsx
@@ -1,25 +1,22 @@
 import { timeout } from "../../utils";
 import { HtmlEditorApiClient } from "../../abstractions/html-editor-api-client";
-import { ResultWithoutExpectedErrors } from "../../abstractions/common/result-types";
+import { Result } from "../../abstractions/common/result-types";
 import { Design } from "react-email-editor";
 import sampleUnlayerDesign from "./sample-unlayer-design.json";
 
 export class DummyHtmlEditorApiClient implements HtmlEditorApiClient {
-  public getCampaignContent: (
-    campaignId: string
-  ) => Promise<ResultWithoutExpectedErrors<Design>> = async (
-    campaignId: string
-  ) => {
-    console.log("Begin getCampaignContent...", {
-      campaignId,
-    });
-    await timeout(1000);
+  public getCampaignContent: (campaignId: string) => Promise<Result<Design>> =
+    async (campaignId: string) => {
+      console.log("Begin getCampaignContent...", {
+        campaignId,
+      });
+      await timeout(1000);
 
-    const result: ResultWithoutExpectedErrors<Design> = {
-      success: true,
-      value: sampleUnlayerDesign,
+      const result: Result<Design> = {
+        success: true,
+        value: sampleUnlayerDesign,
+      };
+      console.log("End getCampaignContent", { result });
+      return result;
     };
-    console.log("End getCampaignContent", { result });
-    return result;
-  };
 }


### PR DESCRIPTION
Hi @FromDoppler/doppler-editors and @FromDoppler/doppler-webapp!

During my vacations, I have learned a little more about generic types in TypeScript and I found the fix for a `// TODO` that we had in [Doppler WebApp](https://github.com/FromDoppler/doppler-webapp) for more than 3 years: https://github.com/FromDoppler/doppler-webapp/blob/ff9d697526b7f8338a8f70a8b2846a1dc1f5f22d/src/doppler-types.ts#L11

@jcamposmk maybe you can apply this same change in [Doppler WebApp](https://github.com/FromDoppler/doppler-webapp), I know that it is not so important, but is nicer.

This is only a change in the types, the behavior is exactly the same as before. As a second step, I am thinking about removing `UnexpectedError`s and using exceptions for them.

In my opinion, it is very easy to forget a catch-all in the service implementation, and React Query (I want to use it) is ready to deal with them: https://react-query.tanstack.com/guides/queries#query-basics

What do you think?