### PR TITLE
fix: update HTML Editor API client to the new schema

### DIFF
--- a/src/implementations/HtmlEditorApiClientImpl.test.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.test.ts
@@ -22,7 +22,16 @@ describe(HtmlEditorApiClientImpl.name, () => {
         current: authenticatedSession,
       } as AppSessionStateAccessor;
 
-      const apiResponse = {};
+      const meta = {
+        body: {
+          rows: [],
+        },
+      };
+
+      const apiResponse = {
+        htmlContent: "<html></html>",
+        meta,
+      };
 
       const appConfiguration = {
         htmlEditorApiBaseUrl,
@@ -58,12 +67,12 @@ describe(HtmlEditorApiClientImpl.name, () => {
       expect(request).toBeCalledWith({
         headers: { Authorization: `Bearer ${jwtToken}` },
         method: "GET",
-        url: `/accounts/${dopplerAccountName}/campaigns/${campaignId}/content/design`,
+        url: `/accounts/${dopplerAccountName}/campaigns/${campaignId}/content`,
       });
 
       expect(result).toEqual({
         success: true,
-        value: apiResponse, // if we sanitize the input this behavior will change
+        value: meta, // if we sanitize the input this behavior will change
       });
     });
 

--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -46,13 +46,11 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
 
   async getCampaignContent(campaignId: string): Promise<Result<Design>> {
     try {
-      const response = await this.GET<any>(
-        `/campaigns/${campaignId}/content/design`
-      );
+      const response = await this.GET<any>(`/campaigns/${campaignId}/content`);
       return {
         success: true,
         // TODO: consider to sanitize and validate this response
-        value: response.data,
+        value: response.data.meta,
       };
     } catch (error) {
       return {


### PR DESCRIPTION
Hi team!

This is the complementary change to https://github.com/FromDoppler/doppler-html-editor-api/pull/21

Could you review it?