### PR TITLE
Refactor unexpected errors

### DIFF
--- a/src/abstractions/common/result-types.ts
+++ b/src/abstractions/common/result-types.ts
@@ -2,13 +2,11 @@ type SuccessResult<TResult> = TResult extends void
   ? { success: true }
   : { success: true; value: TResult };
 
-type UnexpectedError = { success: false; unexpectedError: any };
-
 type ErrorResult<TExpectedError> = { success: false; error: TExpectedError };
 
 export type Result<
   TResult = void,
   TExpectedError = void
 > = TExpectedError extends void
-  ? SuccessResult<TResult> | UnexpectedError
-  : SuccessResult<TResult> | ErrorResult<TExpectedError> | UnexpectedError;
+  ? SuccessResult<TResult>
+  : SuccessResult<TResult> | ErrorResult<TExpectedError>;

--- a/src/abstractions/doppler-legacy-client/index.ts
+++ b/src/abstractions/doppler-legacy-client/index.ts
@@ -1,6 +1,6 @@
 import { Result } from "../common/result-types";
 
-export type DopplerLegacyUserData = {
+type DopplerLegacyUserData = {
   jwtToken: string;
   user: {
     email: string;
@@ -14,6 +14,16 @@ export type DopplerLegacyUserData = {
   unlayerUser: { id: string; signature: string };
 };
 
+type DopplerUserDataNotAvailableError = {
+  userDataNotAvailable: true;
+  innerError: unknown;
+};
+
+export type GetDopplerUserDataResult = Result<
+  DopplerLegacyUserData,
+  DopplerUserDataNotAvailableError
+>;
+
 export interface DopplerLegacyClient {
-  getDopplerUserData: () => Promise<Result<DopplerLegacyUserData>>;
+  getDopplerUserData: () => Promise<GetDopplerUserDataResult>;
 }

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -34,11 +34,11 @@ describe(Campaign.name, () => {
     // Arrange
     const idCampaign = "1234";
 
-    let resolveGetCampaignContentPromise: any;
+    let rejectGetCampaignContentPromise: any;
     const getCampaignContent = jest.fn(
       () =>
-        new Promise((resolve) => {
-          resolveGetCampaignContentPromise = resolve;
+        new Promise((_, reject) => {
+          rejectGetCampaignContentPromise = reject;
         })
     );
 
@@ -71,7 +71,7 @@ describe(Campaign.name, () => {
     expect(errorMessageEl).toBeNull();
 
     // Act
-    resolveGetCampaignContentPromise({ success: false, unexpectedError: true });
+    rejectGetCampaignContentPromise(true);
 
     // Assert
     await screen.findByTestId(errorMessageTestId);

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -30,13 +30,13 @@ export const Campaign = () => {
       });
     } else {
       // TODO: Implement ReactQuery
-      const result = await htmlEditorApiClient.getCampaignContent(idCampaign);
-      if (result.success) {
+      try {
+        const result = await htmlEditorApiClient.getCampaignContent(idCampaign);
         setDesign(result.value);
         setState({ loading: false });
-      } else {
+      } catch (error) {
         setState({
-          error: result.unexpectedError,
+          error: error,
           loading: false,
         });
       }

--- a/src/implementations/DopplerLegacyClientImpl.test.ts
+++ b/src/implementations/DopplerLegacyClientImpl.test.ts
@@ -1,12 +1,11 @@
 import { AppConfiguration } from "../abstractions";
 import { DopplerLegacyClientImpl } from "./DopplerLegacyClientImpl";
 import { AxiosRequestConfig, AxiosResponse, AxiosStatic } from "axios";
-import { DopplerLegacyUserData } from "../abstractions/doppler-legacy-client";
 
 describe(DopplerLegacyClientImpl.name, () => {
   it("should be return a legacy user data successfully", async () => {
     // Arrange
-    const dopplerUserDataMock: DopplerLegacyUserData = {
+    const dopplerUserDataMock = {
       jwtToken: "session_token",
       user: {
         email: "user@email",
@@ -25,10 +24,7 @@ describe(DopplerLegacyClientImpl.name, () => {
     const axiosInstanceMock = {
       create() {
         return {
-          async get(
-            url: string,
-            config?: AxiosRequestConfig
-          ): Promise<AxiosResponse<DopplerLegacyUserData | any>> {
+          async get(url: string, config?: AxiosRequestConfig) {
             return {
               data: {
                 ...dopplerUserDataMock,
@@ -69,7 +65,7 @@ describe(DopplerLegacyClientImpl.name, () => {
           async get(
             url: string,
             config?: AxiosRequestConfig
-          ): Promise<AxiosResponse<DopplerLegacyUserData | any>> {
+          ): Promise<AxiosResponse<any>> {
             throw errorMock;
           },
         };
@@ -87,7 +83,10 @@ describe(DopplerLegacyClientImpl.name, () => {
     // Assert
     expect(result).toEqual({
       success: false,
-      unexpectedError: errorMock,
+      error: {
+        userDataNotAvailable: true,
+        innerError: errorMock,
+      },
     });
   });
 });

--- a/src/implementations/DopplerLegacyClientImpl.ts
+++ b/src/implementations/DopplerLegacyClientImpl.ts
@@ -1,9 +1,8 @@
 import {
   DopplerLegacyClient,
-  DopplerLegacyUserData,
+  GetDopplerUserDataResult,
 } from "../abstractions/doppler-legacy-client";
-import { Result } from "../abstractions/common/result-types";
-import { AxiosInstance, AxiosResponse, AxiosStatic } from "axios";
+import { AxiosInstance, AxiosStatic } from "axios";
 import { AppConfiguration } from "../abstractions";
 
 export class DopplerLegacyClientImpl implements DopplerLegacyClient {
@@ -22,10 +21,9 @@ export class DopplerLegacyClientImpl implements DopplerLegacyClient {
     });
   }
 
-  async getDopplerUserData(): Promise<Result<DopplerLegacyUserData>> {
+  async getDopplerUserData(): Promise<GetDopplerUserDataResult> {
     try {
-      const axiosResponse: AxiosResponse<DopplerLegacyUserData> =
-        await this.axios.get("/WebApp/GetUserData");
+      const axiosResponse = await this.axios.get("/WebApp/GetUserData");
       const { jwtToken, user, unlayerUser } = axiosResponse.data;
       return {
         success: true,
@@ -50,7 +48,10 @@ export class DopplerLegacyClientImpl implements DopplerLegacyClient {
       console.error("Error loading GetUserData", error);
       return {
         success: false,
-        unexpectedError: error,
+        error: {
+          userDataNotAvailable: true,
+          innerError: error,
+        },
       };
     }
   }

--- a/src/implementations/HtmlEditorApiClientImpl.test.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.test.ts
@@ -76,7 +76,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
       });
     });
 
-    it("should return error result when there is an exception", async () => {
+    it("should throw error result when an unexpected error occurs", async () => {
       // Arrange
       const error = new Error("Network error");
       const appSessionStateAccessor = {
@@ -103,14 +103,11 @@ describe(HtmlEditorApiClientImpl.name, () => {
         appConfiguration,
       });
 
-      // Act
-      const result = await sut.getCampaignContent("12345");
-
       // Assert
-      expect(result).toEqual({
-        success: false,
-        unexpectedError: error,
-      });
+      await expect(async () => {
+        // Act
+        await sut.getCampaignContent("12345");
+      }).rejects.toThrowError(error);
     });
 
     it.each([
@@ -118,7 +115,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
       { sessionStatus: "unknown" },
       { sessionStatus: "weird inexistent status" },
     ])(
-      "should return error result when the session is not authenticated ($sessionStatus)",
+      "should throw error result when the session is not authenticated ($sessionStatus)",
       async ({ sessionStatus }) => {
         // Arrange
         const appSessionStateAccessor = {
@@ -145,15 +142,14 @@ describe(HtmlEditorApiClientImpl.name, () => {
           appConfiguration,
         });
 
-        // Act
-        const result = await sut.getCampaignContent("12345");
+        // Assert
+        await expect(async () => {
+          // Act
+          await sut.getCampaignContent("12345");
+        }).rejects.toThrowError(new Error("Authenticated session required"));
 
         // Assert
         expect(request).not.toBeCalled();
-        expect(result).toEqual({
-          success: false,
-          unexpectedError: new Error("Authenticated session required"),
-        });
       }
     );
   });

--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -45,18 +45,11 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
   }
 
   async getCampaignContent(campaignId: string): Promise<Result<Design>> {
-    try {
-      const response = await this.GET<any>(`/campaigns/${campaignId}/content`);
-      return {
-        success: true,
-        // TODO: consider to sanitize and validate this response
-        value: response.data.meta,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        unexpectedError: error,
-      };
-    }
+    const response = await this.GET<any>(`/campaigns/${campaignId}/content`);
+    return {
+      success: true,
+      // TODO: consider to sanitize and validate this response
+      value: response.data.meta,
+    };
   }
 }

--- a/src/implementations/dummies/doppler-legacy-client.tsx
+++ b/src/implementations/dummies/doppler-legacy-client.tsx
@@ -1,20 +1,19 @@
 import { timeout } from "../../utils";
 import {
   DopplerLegacyClient,
-  DopplerLegacyUserData,
+  GetDopplerUserDataResult,
 } from "../../abstractions/doppler-legacy-client";
-import { Result } from "../../abstractions/common/result-types";
 
 let counter = 0;
 
 export class DummyDopplerLegacyClient implements DopplerLegacyClient {
-  public getDopplerUserData: () => Promise<Result<DopplerLegacyUserData>> =
+  public getDopplerUserData: () => Promise<GetDopplerUserDataResult> =
     async () => {
       try {
         console.log("Begin getDopplerUserData...");
         await timeout(3000);
-        const result: Result<DopplerLegacyUserData> = {
-          success: true,
+        const result = {
+          success: true as const,
           value: {
             jwtToken: `jwtToken-${counter++}`,
             user: {
@@ -38,7 +37,10 @@ export class DummyDopplerLegacyClient implements DopplerLegacyClient {
       } catch (e) {
         return {
           success: false,
-          unexpectedError: e,
+          error: {
+            userDataNotAvailable: true,
+            innerError: e,
+          },
         };
       }
     };


### PR DESCRIPTION
Hi @FromDoppler/doppler-editors and @FromDoppler/doppler-webapp teams!

I think that my previous approach of avoiding exceptions completely when calling services is not sustainable.

It is easy that a developer forgot to add the full-scope try/catch.

So, I decided to keep the `Result` type for the happy path and for expected errors, for example, "not found", etc.

I think that this new approach also fits very well with React Query.

What do you think?