### PR TITLE
fix: only show editor not authenticated error when editor is not hidden

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -39,8 +39,17 @@ export const Editor = ({
     }
   }, [emailEditorLoaded, setEditorState]);
 
+  const containerStyle = {
+    height: "calc(100% - 70px)",
+    display: hidden ? "none" : "flex",
+  };
+
   if (appSessionStateAccessor.current.status !== "authenticated") {
-    return <p>This component requires an authenticated session</p>;
+    return (
+      <div style={containerStyle} {...otherProps}>
+        <p>This component requires an authenticated session</p>;
+      </div>
+    );
   }
 
   const { id, signature } = appSessionStateAccessor.current.unlayerUser;
@@ -61,11 +70,6 @@ export const Editor = ({
       loaderUrl,
       `(new AssetServices()).load('${unlayerEditorManifestUrl}', []);`,
     ],
-  };
-
-  const containerStyle = {
-    height: "calc(100% - 70px)",
-    display: hidden ? "none" : "flex",
   };
 
   return (


### PR DESCRIPTION
Very minor fix of this:

![2022-02-01_15-25-05 (1)](https://user-images.githubusercontent.com/1157864/152029219-e0f9795a-c37f-48ca-9865-08b7e95f9223.gif)

