### PR TITLE
chore: better data for demo in Dummy HtmlEditorApiClient

### DIFF
--- a/src/implementations/dummies/html-editor-api-client.tsx
+++ b/src/implementations/dummies/html-editor-api-client.tsx
@@ -12,9 +12,14 @@ export class DummyHtmlEditorApiClient implements HtmlEditorApiClient {
       });
       await timeout(1000);
 
+      const text = `SOY CampaignDesign #${campaignId} ${new Date().getMinutes()}`;
+      const value = JSON.parse(JSON.stringify(sampleUnlayerDesign)) as any;
+      value.body.rows[0].columns[0].contents[0].values.text = text;
+      value.idCampaign = campaignId;
+
       const result: Result<Design> = {
         success: true,
-        value: sampleUnlayerDesign,
+        value,
       };
       console.log("End getCampaignContent", { result });
       return result;


### PR DESCRIPTION
Hi team!

I think that these changes in our dummy HttpEditorApiClient implementation will be really useful to have a more real experience.

Here you have two examples:

**With the code as it is right now in `main` (without React Query)**

![2022-02-01_16-10-34 (1)](https://user-images.githubusercontent.com/1157864/152036182-50b13874-c566-48c9-8e12-88e9e399c6c5.gif)

**With React Query (see #82)**

![2022-02-01_16-15-42 (1)](https://user-images.githubusercontent.com/1157864/152036269-7223c673-db0d-40d5-a991-8992429721b3.gif)

