### PR TITLE
Remove unnecessary validation of campaign ID

### DIFF
--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -15,7 +15,7 @@ export const editorTopBarTestId = "editor-top-bar-message";
 
 export const Campaign = () => {
   const { htmlEditorApiClient } = useAppServices();
-  const { idCampaign } = useParams();
+  const { idCampaign } = useParams() as Readonly<{ idCampaign: string }>;
   const { getDesign, setDesign, unsetDesign } = useSingletonEditor();
 
   const [state, setState] = useState<LoadingDesignState>({

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -23,23 +23,16 @@ export const Campaign = () => {
   });
 
   const loadDesign = useCallback(async () => {
-    if (!idCampaign) {
+    // TODO: Implement ReactQuery
+    try {
+      const result = await htmlEditorApiClient.getCampaignContent(idCampaign);
+      setDesign(result.value);
+      setState({ loading: false });
+    } catch (error) {
       setState({
-        error: "Missing idCampaign",
+        error: error,
         loading: false,
       });
-    } else {
-      // TODO: Implement ReactQuery
-      try {
-        const result = await htmlEditorApiClient.getCampaignContent(idCampaign);
-        setDesign(result.value);
-        setState({ loading: false });
-      } catch (error) {
-        setState({
-          error: error,
-          loading: false,
-        });
-      }
     }
   }, [idCampaign, htmlEditorApiClient, setDesign]);
 


### PR DESCRIPTION
I think that our routings are enough restrictive, so, the Campaign component will not be renderer if the campaign id is _null_, _undefined_ or _empty_.

<img width="991" alt="image" src="https://user-images.githubusercontent.com/1157864/152149368-b3b2098a-0acd-4e1d-857d-a9f24819b333.png">

What do you think?