### PR TITLE
refactor: replace getDesign and getHtml by getUnlayerData

### DIFF
--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -174,8 +174,7 @@ describe(Campaign.name, () => {
       hidden: false,
       setDesign: () => {},
       unsetDesign: () => {},
-      getDesign: () => Promise.resolve(design),
-      getHtml: () => Promise.resolve(htmlContent),
+      getUnlayerData: () => Promise.resolve({ design, html: htmlContent }),
     };
 
     const htmlEditorApiClient = {

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -13,7 +13,7 @@ export const editorTopBarTestId = "editor-top-bar-message";
 
 export const Campaign = () => {
   const { idCampaign } = useParams() as Readonly<{ idCampaign: string }>;
-  const { getDesign, setDesign, unsetDesign, getHtml } = useSingletonEditor();
+  const { setDesign, unsetDesign, getUnlayerData } = useSingletonEditor();
 
   const campaignContentQuery = useGetCampaignContent(idCampaign);
   const campaignContentMutation = useUpdateCampaignContent();
@@ -33,9 +33,8 @@ export const Campaign = () => {
   }
 
   const onSave = async () => {
-    const design = await getDesign();
-    const htmlContent = await getHtml();
-    campaignContentMutation.mutate({ idCampaign, design, htmlContent });
+    const { design, html } = await getUnlayerData();
+    campaignContentMutation.mutate({ idCampaign, design, htmlContent: html });
   };
 
   return (

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -9,9 +9,8 @@ export type EditorState =
 export interface ISingletonDesignContext {
   hidden: boolean;
   setDesign: (d: Design | undefined) => void;
-  getHtml: () => Promise<string>;
+  getUnlayerData: () => Promise<HtmlExport>;
   unsetDesign: () => void;
-  getDesign: () => Promise<Design>;
 }
 
 export const emptyDesign = {
@@ -23,9 +22,8 @@ export const emptyDesign = {
 export const SingletonDesignContext = createContext<ISingletonDesignContext>({
   hidden: true,
   setDesign: () => {},
-  getHtml: () => Promise.resolve(""),
+  getUnlayerData: () => Promise.resolve({ design: {}, html: "" } as HtmlExport),
   unsetDesign: () => {},
-  getDesign: () => Promise.resolve(emptyDesign),
 });
 
 export const useSingletonEditor = () => useContext(SingletonDesignContext);
@@ -43,24 +41,16 @@ export const SingletonEditorProvider = ({
     isLoaded: false,
   });
 
-  const getHtml = () => {
+  const getUnlayerData = () => {
     if (!editorState.isLoaded) {
-      return Promise.resolve("");
+      return Promise.resolve({
+        design: {},
+        html: "",
+      } as HtmlExport);
     }
-    return new Promise<string>((resolve) => {
+    return new Promise<HtmlExport>((resolve) => {
       editorState.unlayer.exportHtml((htmlExport: HtmlExport) => {
-        resolve(htmlExport.html);
-      });
-    });
-  };
-
-  const getDesign = () => {
-    if (!editorState.isLoaded) {
-      return Promise.resolve(emptyDesign);
-    }
-    return new Promise<Design>((resolve) => {
-      editorState.unlayer.exportHtml((htmlExport: HtmlExport) => {
-        resolve(htmlExport.design);
+        resolve(htmlExport);
       });
     });
   };
@@ -75,8 +65,7 @@ export const SingletonEditorProvider = ({
     hidden,
     setDesign,
     unsetDesign: () => setDesign(undefined),
-    getDesign,
-    getHtml,
+    getUnlayerData,
   };
 
   return (


### PR DESCRIPTION
As [we have discussed](https://makingsense.slack.com/archives/CLBEN4JAV/p1643828158421049), at the moment we are fine with `getUnlayerData` only.