### PR TITLE
refactor: move SingletonEditorProvider usage to index.tsx

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -2,7 +2,6 @@ import { Link, Outlet } from "react-router-dom";
 import { useAppServices } from "./AppServicesContext";
 import logo from "./logo.svg";
 import "./Main.css";
-import { SingletonEditorProvider } from "./SingletonEditor";
 
 export function Main() {
   const {
@@ -28,9 +27,7 @@ export function Main() {
           </div>
         </nav>
       </header>
-      <SingletonEditorProvider>
-        <Outlet />
-      </SingletonEditorProvider>
+      <Outlet />
     </div>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import { configureApp } from "./composition-root";
 import { AppServicesProvider } from "./components/AppServicesContext";
 import { AppSessionStateProvider } from "./components/AppSessionStateContext";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { SingletonEditorProvider } from "./components/SingletonEditor";
 
 const customConfiguration =
   (window as any)["editors-webapp-configuration"] || {};
@@ -27,7 +28,9 @@ render(
           appSessionStateMonitor={appSessionStateMonitor}
         >
           <BrowserRouter basename={appServices.appConfiguration.basename}>
-            <App />
+            <SingletonEditorProvider>
+              <App />
+            </SingletonEditorProvider>
           </BrowserRouter>
         </AppSessionStateProvider>
       </AppServicesProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,17 +23,17 @@ const queryClient = new QueryClient();
 render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <AppServicesProvider appServices={appServices}>
-        <AppSessionStateProvider
-          appSessionStateMonitor={appSessionStateMonitor}
-        >
-          <BrowserRouter basename={appServices.appConfiguration.basename}>
+      <BrowserRouter basename={appServices.appConfiguration.basename}>
+        <AppServicesProvider appServices={appServices}>
+          <AppSessionStateProvider
+            appSessionStateMonitor={appSessionStateMonitor}
+          >
             <SingletonEditorProvider>
               <App />
             </SingletonEditorProvider>
-          </BrowserRouter>
-        </AppSessionStateProvider>
-      </AppServicesProvider>
+          </AppSessionStateProvider>
+        </AppServicesProvider>
+      </BrowserRouter>
     </QueryClientProvider>
   </StrictMode>,
   document.getElementById("root")


### PR DESCRIPTION
Hi team!

I think that having `SingletonEditorProvider` in `index.tsx` makes it clear and predictable.

What do you think?