### PR TITLE
DE-450 - Preparation refactoring

### DIFF
--- a/src/abstractions/domain/content.ts
+++ b/src/abstractions/domain/content.ts
@@ -1,0 +1,3 @@
+import { Design } from "react-email-editor";
+
+export type Content = { htmlContent: string; design: Design; type: "unlayer" };

--- a/src/abstractions/html-editor-api-client/index.ts
+++ b/src/abstractions/html-editor-api-client/index.ts
@@ -1,12 +1,10 @@
-import { Design } from "react-email-editor";
 import { Result } from "../common/result-types";
-
-export type CampaignContent = { htmlContent: string; design: Design };
+import { Content } from "../domain/content";
 
 export interface HtmlEditorApiClient {
-  getCampaignContent: (campaignId: string) => Promise<Result<Design>>;
+  getCampaignContent: (campaignId: string) => Promise<Result<Content>>;
   updateCampaignContent: (
     campaignId: string,
-    content: CampaignContent
+    content: Content
   ) => Promise<Result>;
 }

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Design } from "react-email-editor";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -6,7 +6,6 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { AppServices } from "../abstractions";
 import { Field } from "../abstractions/doppler-rest-api-client";
 import { HtmlEditorApiClient } from "../abstractions/html-editor-api-client";
-import { timeout } from "../utils";
 import { AppServicesProvider } from "./AppServicesContext";
 import {
   Campaign,

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -175,9 +175,10 @@ describe(Campaign.name, () => {
 
     const singletonEditorContext: ISingletonDesignContext = {
       hidden: false,
-      setDesign: () => {},
-      unsetDesign: () => {},
-      getUnlayerData: () => Promise.resolve({ design, html: htmlContent }),
+      setContent: () => {},
+      unsetContent: () => {},
+      getContent: () =>
+        Promise.resolve({ design, htmlContent, type: "unlayer" }),
     };
 
     const htmlEditorApiClient = {
@@ -211,6 +212,7 @@ describe(Campaign.name, () => {
       expect(updateCampaignContent).toHaveBeenCalledWith(idCampaign, {
         design,
         htmlContent,
+        type: "unlayer",
       });
     });
   });

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -13,15 +13,15 @@ export const editorTopBarTestId = "editor-top-bar-message";
 
 export const Campaign = () => {
   const { idCampaign } = useParams() as Readonly<{ idCampaign: string }>;
-  const { setDesign, unsetDesign, getUnlayerData } = useSingletonEditor();
+  const { setContent, unsetContent, getContent } = useSingletonEditor();
 
   const campaignContentQuery = useGetCampaignContent(idCampaign);
   const campaignContentMutation = useUpdateCampaignContent();
 
   useEffect(() => {
-    setDesign(campaignContentQuery.data);
-    return () => unsetDesign();
-  }, [campaignContentQuery.data, unsetDesign, setDesign]);
+    setContent(campaignContentQuery.data);
+    return () => unsetContent();
+  }, [campaignContentQuery.data, unsetContent, setContent]);
 
   if (campaignContentQuery.error) {
     return (
@@ -33,8 +33,8 @@ export const Campaign = () => {
   }
 
   const onSave = async () => {
-    const { design, html } = await getUnlayerData();
-    campaignContentMutation.mutate({ idCampaign, design, htmlContent: html });
+    const content = await getContent();
+    campaignContentMutation.mutate({ idCampaign, content });
   };
 
   return (

--- a/src/components/SingletonEditor.test.tsx
+++ b/src/components/SingletonEditor.test.tsx
@@ -39,8 +39,6 @@ const queryClient = new QueryClient({
   },
 });
 
-const noop = () => {};
-
 describe(Editor.name, () => {
   it("should show and hide EmailEditor when design is set and unset", () => {
     // Arrange

--- a/src/components/SingletonEditor.test.tsx
+++ b/src/components/SingletonEditor.test.tsx
@@ -45,11 +45,21 @@ describe(Editor.name, () => {
     const appServices = defaultAppServices as AppServices;
 
     const DemoComponent = () => {
-      const { setDesign, unsetDesign } = useSingletonEditor();
+      const { setContent, unsetContent } = useSingletonEditor();
       return (
         <>
-          <button onClick={() => setDesign({} as Design)}>LoadDesign</button>
-          <button onClick={() => unsetDesign()}>UnloadDesign</button>
+          <button
+            onClick={() =>
+              setContent({
+                design: {} as Design,
+                htmlContent: "",
+                type: "unlayer",
+              })
+            }
+          >
+            LoadDesign
+          </button>
+          <button onClick={() => unsetContent()}>UnloadDesign</button>
         </>
       );
     };

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -58,6 +58,11 @@ export const SingletonEditorProvider = ({
     }
     return new Promise<Content>((resolve) => {
       editorState.unlayer.exportHtml((htmlExport: HtmlExport) => {
+        if (!htmlExport.design) {
+          throw new Error(
+            `Not implemented: Export results without 'design' property are not supported yet.`
+          );
+        }
         resolve({
           design: htmlExport.design,
           htmlContent: htmlExport.html,
@@ -78,6 +83,10 @@ export const SingletonEditorProvider = ({
         editorState.unlayer.loadDesign(content.design);
         return;
       }
+
+      throw new Error(
+        `Not implemented: Content type '${content.type}' is not supported yet.`
+      );
     }
   }, [content, editorState]);
 

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { Editor } from "./Editor";
-import EmailEditor, { Design, HtmlExport } from "react-email-editor";
+import EmailEditor, { HtmlExport } from "react-email-editor";
+import { Content } from "../abstractions/domain/content";
 
 export type EditorState =
   | { isLoaded: false; unlayer: undefined }
@@ -8,9 +9,9 @@ export type EditorState =
 
 export interface ISingletonDesignContext {
   hidden: boolean;
-  setDesign: (d: Design | undefined) => void;
-  getUnlayerData: () => Promise<HtmlExport>;
-  unsetDesign: () => void;
+  setContent: (c: Content | undefined) => void;
+  getContent: () => Promise<Content>;
+  unsetContent: () => void;
 }
 
 export const emptyDesign = {
@@ -21,9 +22,14 @@ export const emptyDesign = {
 
 export const SingletonDesignContext = createContext<ISingletonDesignContext>({
   hidden: true,
-  setDesign: () => {},
-  getUnlayerData: () => Promise.resolve({ design: {}, html: "" } as HtmlExport),
-  unsetDesign: () => {},
+  setContent: () => {},
+  getContent: () =>
+    Promise.resolve({
+      design: emptyDesign,
+      htmlContent: "",
+      type: "unlayer",
+    } as Content),
+  unsetContent: () => {},
 });
 
 export const useSingletonEditor = () => useContext(SingletonDesignContext);
@@ -34,38 +40,52 @@ export const SingletonEditorProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [design, setDesign] = useState<Design | undefined>();
-  const hidden = !design;
+  const [content, setContent] = useState<Content | undefined>();
+  const hidden = !content;
   const [editorState, setEditorState] = useState<EditorState>({
     unlayer: undefined,
     isLoaded: false,
   });
 
-  const getUnlayerData = () => {
+  const getContent = () => {
     if (!editorState.isLoaded) {
-      return Promise.resolve({
-        design: {},
-        html: "",
-      } as HtmlExport);
+      const fallbackResult: Content = {
+        design: emptyDesign,
+        htmlContent: "",
+        type: "unlayer",
+      };
+      return Promise.resolve(fallbackResult);
     }
-    return new Promise<HtmlExport>((resolve) => {
+    return new Promise<Content>((resolve) => {
       editorState.unlayer.exportHtml((htmlExport: HtmlExport) => {
-        resolve(htmlExport);
+        resolve({
+          design: htmlExport.design,
+          htmlContent: htmlExport.html,
+          type: "unlayer",
+        });
       });
     });
   };
 
   useEffect(() => {
     if (editorState.isLoaded) {
-      editorState.unlayer.loadDesign(design || emptyDesign);
+      if (!content) {
+        editorState.unlayer.loadDesign(emptyDesign);
+        return;
+      }
+
+      if (content.type === "unlayer") {
+        editorState.unlayer.loadDesign(content.design);
+        return;
+      }
     }
-  }, [design, editorState]);
+  }, [content, editorState]);
 
   const defaultContext: ISingletonDesignContext = {
     hidden,
-    setDesign,
-    unsetDesign: () => setDesign(undefined),
-    getUnlayerData,
+    setContent,
+    unsetContent: () => setContent(undefined),
+    getContent,
   };
 
   return (

--- a/src/implementations/HtmlEditorApiClientImpl.test.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.test.ts
@@ -22,6 +22,8 @@ describe(HtmlEditorApiClientImpl.name, () => {
         current: authenticatedSession,
       } as AppSessionStateAccessor;
 
+      const htmlContent = "<html></html>";
+
       const meta = {
         body: {
           rows: [],
@@ -29,7 +31,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
       };
 
       const apiResponse = {
-        htmlContent: "<html></html>",
+        htmlContent,
         meta,
       };
 
@@ -72,7 +74,11 @@ describe(HtmlEditorApiClientImpl.name, () => {
 
       expect(result).toEqual({
         success: true,
-        value: meta, // if we sanitize the input this behavior will change
+        value: {
+          design: meta,
+          htmlContent,
+          type: "unlayer",
+        },
       });
     });
 

--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -1,12 +1,9 @@
 import { Result } from "../abstractions/common/result-types";
 import { AppConfiguration } from "../abstractions";
-import {
-  CampaignContent,
-  HtmlEditorApiClient,
-} from "../abstractions/html-editor-api-client";
-import { Design } from "react-email-editor";
+import { HtmlEditorApiClient } from "../abstractions/html-editor-api-client";
 import { AxiosStatic, Method } from "axios";
 import { AppSessionStateAccessor } from "../abstractions/app-session";
+import { Content } from "../abstractions/domain/content";
 
 export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
   private axios;
@@ -56,18 +53,23 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
     return this.request<any>("PUT", url, data);
   }
 
-  async getCampaignContent(campaignId: string): Promise<Result<Design>> {
+  async getCampaignContent(campaignId: string): Promise<Result<Content>> {
     const response = await this.GET<any>(`/campaigns/${campaignId}/content`);
+
     return {
       success: true,
-      // TODO: consider to sanitize and validate this response
-      value: response.data.meta,
+      value: {
+        // TODO: consider to sanitize and validate this response
+        design: response.data.meta,
+        htmlContent: response.data.htmlContent,
+        type: "unlayer",
+      },
     };
   }
 
   async updateCampaignContent(
     campaignId: string,
-    content: CampaignContent
+    content: Content
   ): Promise<Result> {
     const body = {
       meta: content.design,

--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -56,6 +56,12 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
   async getCampaignContent(campaignId: string): Promise<Result<Content>> {
     const response = await this.GET<any>(`/campaigns/${campaignId}/content`);
 
+    if (!response.data.meta) {
+      throw new Error(
+        `Not implemented: Content responses without 'meta' property are not supported yet.`
+      );
+    }
+
     return {
       success: true,
       value: {
@@ -71,6 +77,11 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
     campaignId: string,
     content: Content
   ): Promise<Result> {
+    if (content.type !== "unlayer") {
+      throw new Error(
+        `Not implemented: Content type '${content.type}' is not supported yet.`
+      );
+    }
     const body = {
       meta: content.design,
       htmlContent: content.htmlContent,

--- a/src/implementations/dummies/html-editor-api-client.tsx
+++ b/src/implementations/dummies/html-editor-api-client.tsx
@@ -1,14 +1,11 @@
 import { timeout } from "../../utils";
-import {
-  CampaignContent,
-  HtmlEditorApiClient,
-} from "../../abstractions/html-editor-api-client";
+import { HtmlEditorApiClient } from "../../abstractions/html-editor-api-client";
 import { Result } from "../../abstractions/common/result-types";
-import { Design } from "react-email-editor";
 import sampleUnlayerDesign from "./sample-unlayer-design.json";
+import { Content } from "../../abstractions/domain/content";
 
 export class DummyHtmlEditorApiClient implements HtmlEditorApiClient {
-  public getCampaignContent: (campaignId: string) => Promise<Result<Design>> =
+  public getCampaignContent: (campaignId: string) => Promise<Result<Content>> =
     async (campaignId: string) => {
       console.log("Begin getCampaignContent...", {
         campaignId,
@@ -16,11 +13,17 @@ export class DummyHtmlEditorApiClient implements HtmlEditorApiClient {
       await timeout(1000);
 
       const text = `SOY CampaignDesign #${campaignId} ${new Date().getMinutes()}`;
-      const value = JSON.parse(JSON.stringify(sampleUnlayerDesign)) as any;
-      value.body.rows[0].columns[0].contents[0].values.text = text;
-      value.idCampaign = campaignId;
+      const design = JSON.parse(JSON.stringify(sampleUnlayerDesign)) as any;
+      design.body.rows[0].columns[0].contents[0].values.text = text;
+      design.idCampaign = campaignId;
 
-      const result: Result<Design> = {
+      const value: Content = {
+        design: design,
+        htmlContent: "<html></html>",
+        type: "unlayer",
+      };
+
+      const result: Result<Content> = {
         success: true,
         value,
       };
@@ -30,7 +33,7 @@ export class DummyHtmlEditorApiClient implements HtmlEditorApiClient {
 
   async updateCampaignContent(
     campaignId: string,
-    content: CampaignContent
+    content: Content
   ): Promise<Result> {
     console.log("Begin updateCampaignContent...", {
       campaignId,

--- a/src/implementations/dummies/html-editor-api-client.tsx
+++ b/src/implementations/dummies/html-editor-api-client.tsx
@@ -12,16 +12,7 @@ export class DummyHtmlEditorApiClient implements HtmlEditorApiClient {
       });
       await timeout(1000);
 
-      const text = `SOY CampaignDesign #${campaignId} ${new Date().getMinutes()}`;
-      const design = JSON.parse(JSON.stringify(sampleUnlayerDesign)) as any;
-      design.body.rows[0].columns[0].contents[0].values.text = text;
-      design.idCampaign = campaignId;
-
-      const value: Content = {
-        design: design,
-        htmlContent: "<html></html>",
-        type: "unlayer",
-      };
+      const value = createUnlayerContent(campaignId);
 
       const result: Result<Content> = {
         success: true,
@@ -44,4 +35,17 @@ export class DummyHtmlEditorApiClient implements HtmlEditorApiClient {
     console.log("End updateCampaignContent");
     return { success: true };
   }
+}
+
+function createUnlayerContent(campaignId: string): Content {
+  const text = `SOY CampaignDesign #${campaignId} ${new Date().getMinutes()}`;
+  const design = JSON.parse(JSON.stringify(sampleUnlayerDesign)) as any;
+  design.body.rows[0].columns[0].contents[0].values.text = text;
+  design.idCampaign = campaignId;
+
+  return {
+    design: design,
+    htmlContent: "<html></html>",
+    type: "unlayer",
+  };
 }

--- a/src/queries/campaign-content-queries.tsx
+++ b/src/queries/campaign-content-queries.tsx
@@ -1,5 +1,5 @@
-import { Design } from "react-email-editor";
 import { QueryFunction, useMutation, useQuery } from "react-query";
+import { Content } from "../abstractions/domain/content";
 import { useAppServices } from "../components/AppServicesContext";
 
 type getCampaignContentQueryKey = {
@@ -17,7 +17,7 @@ export const useGetCampaignContent = (idCampaign: string) => {
     },
   ];
 
-  const queryFn: QueryFunction<Design, getCampaignContentQueryKey> = async (
+  const queryFn: QueryFunction<Content, getCampaignContentQueryKey> = async (
     context
   ) => {
     const [{ idCampaign }] = context.queryKey;
@@ -41,17 +41,11 @@ export const useUpdateCampaignContent = () => {
 
   const updateCampaignContent = ({
     idCampaign,
-    design,
-    htmlContent,
+    content,
   }: {
     idCampaign: string;
-    design: Design;
-    htmlContent: string;
-  }) =>
-    htmlEditorApiClient.updateCampaignContent(idCampaign, {
-      design,
-      htmlContent,
-    });
+    content: Content;
+  }) => htmlEditorApiClient.updateCampaignContent(idCampaign, content);
 
   return useMutation(updateCampaignContent);
 };


### PR DESCRIPTION
Hi team!

It is a preparation step to allow using [Unlayer HTML classic mode](https://examples.unlayer.com/web/legacy-template).

My idea is to have a new domain model `campaign`, by the moment it only supports drag-n-drop Unlayer model, but the next step is to support also support classic model:

```diff
 export type Content =
+  | { htmlContent: string; type: "html" }
   | { htmlContent: string; design: Design; type: "unlayer" };
```

What do you think?