### PR TITLE
DE-450 - Classic mode

### DIFF
--- a/src/abstractions/domain/content.ts
+++ b/src/abstractions/domain/content.ts
@@ -1,3 +1,5 @@
 import { Design } from "react-email-editor";
 
-export type Content = { htmlContent: string; design: Design; type: "unlayer" };
+export type Content =
+  | { htmlContent: string; type: "html" }
+  | { htmlContent: string; design: Design; type: "unlayer" };

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -19,6 +19,8 @@ export function Main() {
           <div>
             <Link to="/invoices">Invoices</Link> |{" "}
             <Link to="/expenses">Expenses</Link> |{" "}
+            <Link to="/campaigns/html123">campaigns/html123</Link> |{" "}
+            <Link to="/campaigns/html456">campaigns/html456</Link> |{" "}
             <Link to="/campaigns/123">campaigns/123</Link> |{" "}
             <Link to="/campaigns/456">campaigns/456</Link> |{" "}
             <Link to="/campaigns/789">campaigns/789</Link> |{" "}

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -85,6 +85,11 @@ export const SingletonEditorProvider = ({
       }
 
       if (content.type === "html") {
+        // Ugly patch because of:
+        // * https://github.com/unlayer/react-email-editor/issues/212
+        // * https://unlayer.canny.io/bug-reports/p/loaddesign-doesnt-reload-for-legacy-templates
+        editorState.unlayer.loadDesign(emptyDesign);
+
         // See https://examples.unlayer.com/web/legacy-template
         editorState.unlayer.loadDesign({
           html: content.htmlContent,

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -59,15 +59,18 @@ export const SingletonEditorProvider = ({
     return new Promise<Content>((resolve) => {
       editorState.unlayer.exportHtml((htmlExport: HtmlExport) => {
         if (!htmlExport.design) {
-          throw new Error(
-            `Not implemented: Export results without 'design' property are not supported yet.`
-          );
+          // It is a legacy template: https://examples.unlayer.com/web/legacy-template
+          resolve({
+            htmlContent: htmlExport.html,
+            type: "html",
+          });
+        } else {
+          resolve({
+            design: htmlExport.design,
+            htmlContent: htmlExport.html,
+            type: "unlayer",
+          });
         }
-        resolve({
-          design: htmlExport.design,
-          htmlContent: htmlExport.html,
-          type: "unlayer",
-        });
       });
     });
   };

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -84,8 +84,19 @@ export const SingletonEditorProvider = ({
         return;
       }
 
+      if (content.type === "html") {
+        // See https://examples.unlayer.com/web/legacy-template
+        editorState.unlayer.loadDesign({
+          html: content.htmlContent,
+          classic: true,
+        } as any);
+        return;
+      }
+
       throw new Error(
-        `Not implemented: Content type '${content.type}' is not supported yet.`
+        `Not implemented: Content type '${
+          (content as any).type
+        }' is not supported yet.`
       );
     }
   }, [content, editorState]);

--- a/src/implementations/HtmlEditorApiClientImpl.test.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.test.ts
@@ -82,6 +82,76 @@ describe(HtmlEditorApiClientImpl.name, () => {
       });
     });
 
+    it("should accept html content responses", async () => {
+      // Arrange
+      const campaignId = "123";
+      const jwtToken = "jwtToken";
+      const dopplerAccountName = "dopplerAccountName";
+      const htmlEditorApiBaseUrl = "htmlEditorApiBaseUrl";
+
+      const authenticatedSession = {
+        status: "authenticated",
+        jwtToken,
+        dopplerAccountName,
+      };
+
+      const appSessionStateAccessor = {
+        current: authenticatedSession,
+      } as AppSessionStateAccessor;
+
+      const htmlContent = "<html></html>";
+
+      const apiResponse = {
+        htmlContent,
+        type: "html",
+      };
+
+      const appConfiguration = {
+        htmlEditorApiBaseUrl,
+      } as AppConfiguration;
+
+      const request = jest.fn(() =>
+        Promise.resolve({
+          data: apiResponse,
+        })
+      );
+
+      const create = jest.fn(() => ({
+        request,
+      }));
+
+      const axiosStatic = {
+        create,
+      } as unknown as AxiosStatic;
+
+      const sut = new HtmlEditorApiClientImpl({
+        axiosStatic,
+        appSessionStateAccessor,
+        appConfiguration,
+      });
+
+      // Act
+      const result = await sut.getCampaignContent(campaignId);
+
+      // Assert
+      expect(create).toBeCalledWith({
+        baseURL: "htmlEditorApiBaseUrl",
+      });
+      expect(request).toBeCalledWith({
+        headers: { Authorization: `Bearer ${jwtToken}` },
+        method: "GET",
+        url: `/accounts/${dopplerAccountName}/campaigns/${campaignId}/content`,
+      });
+
+      expect(result).toEqual({
+        success: true,
+        value: {
+          htmlContent,
+          type: "html",
+        },
+      });
+    });
+
     it("should throw error result when an unexpected error occurs", async () => {
       // Arrange
       const error = new Error("Network error");

--- a/src/implementations/HtmlEditorApiClientImpl.test.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.test.ts
@@ -2,6 +2,8 @@ import { AppConfiguration } from "../abstractions";
 import { AxiosStatic } from "axios";
 import { HtmlEditorApiClientImpl } from "./HtmlEditorApiClientImpl";
 import { AppSessionStateAccessor } from "../abstractions/app-session";
+import { Design } from "react-email-editor";
+import { Content } from "../abstractions/domain/content";
 
 describe(HtmlEditorApiClientImpl.name, () => {
   describe("getCampaignContent", () => {
@@ -228,5 +230,142 @@ describe(HtmlEditorApiClientImpl.name, () => {
         expect(request).not.toBeCalled();
       }
     );
+  });
+
+  describe("updateCampaignContent", () => {
+    it("should PUT unlayer contents", async () => {
+      // Arrange
+      const campaignId = "123";
+      const jwtToken = "jwtToken";
+      const dopplerAccountName = "dopplerAccountName";
+      const htmlEditorApiBaseUrl = "htmlEditorApiBaseUrl";
+
+      const authenticatedSession = {
+        status: "authenticated",
+        jwtToken,
+        dopplerAccountName,
+      };
+
+      const appSessionStateAccessor = {
+        current: authenticatedSession,
+      } as AppSessionStateAccessor;
+
+      const design = { testContent: "test content" } as unknown as Design;
+      const htmlContent = "<html></html>";
+
+      const content: Content = {
+        htmlContent,
+        design,
+        type: "unlayer",
+      };
+
+      const appConfiguration = {
+        htmlEditorApiBaseUrl,
+      } as AppConfiguration;
+
+      const request = jest.fn(() =>
+        Promise.resolve({
+          data: {},
+        })
+      );
+
+      const create = jest.fn(() => ({
+        request,
+      }));
+
+      const axiosStatic = {
+        create,
+      } as unknown as AxiosStatic;
+
+      const sut = new HtmlEditorApiClientImpl({
+        axiosStatic,
+        appSessionStateAccessor,
+        appConfiguration,
+      });
+
+      // Act
+      await sut.updateCampaignContent(campaignId, content);
+
+      // Assert
+      expect(create).toBeCalledWith({
+        baseURL: "htmlEditorApiBaseUrl",
+      });
+      expect(request).toBeCalledWith({
+        headers: { Authorization: `Bearer ${jwtToken}` },
+        method: "PUT",
+        url: `/accounts/${dopplerAccountName}/campaigns/${campaignId}/content`,
+        data: {
+          htmlContent,
+          meta: design,
+          type: "unlayer",
+        },
+      });
+    });
+
+    it("should PUT html contents", async () => {
+      // Arrange
+      const campaignId = "123";
+      const jwtToken = "jwtToken";
+      const dopplerAccountName = "dopplerAccountName";
+      const htmlEditorApiBaseUrl = "htmlEditorApiBaseUrl";
+
+      const authenticatedSession = {
+        status: "authenticated",
+        jwtToken,
+        dopplerAccountName,
+      };
+
+      const appSessionStateAccessor = {
+        current: authenticatedSession,
+      } as AppSessionStateAccessor;
+
+      const htmlContent = "<html></html>";
+
+      const content: Content = {
+        htmlContent,
+        type: "html",
+      };
+
+      const appConfiguration = {
+        htmlEditorApiBaseUrl,
+      } as AppConfiguration;
+
+      const request = jest.fn(() =>
+        Promise.resolve({
+          data: {},
+        })
+      );
+
+      const create = jest.fn(() => ({
+        request,
+      }));
+
+      const axiosStatic = {
+        create,
+      } as unknown as AxiosStatic;
+
+      const sut = new HtmlEditorApiClientImpl({
+        axiosStatic,
+        appSessionStateAccessor,
+        appConfiguration,
+      });
+
+      // Act
+      await sut.updateCampaignContent(campaignId, content);
+
+      // Assert
+      expect(create).toBeCalledWith({
+        baseURL: "htmlEditorApiBaseUrl",
+      });
+      expect(request).toBeCalledWith({
+        headers: { Authorization: `Bearer ${jwtToken}` },
+        method: "PUT",
+        url: `/accounts/${dopplerAccountName}/campaigns/${campaignId}/content`,
+        data: {
+          htmlContent,
+          type: "html",
+        },
+      });
+    });
   });
 });

--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -83,15 +83,18 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
     campaignId: string,
     content: Content
   ): Promise<Result> {
-    if (content.type !== "unlayer") {
-      throw new Error(
-        `Not implemented: Content type '${content.type}' is not supported yet.`
-      );
-    }
-    const body = {
-      meta: content.design,
-      htmlContent: content.htmlContent,
-    };
+    const body =
+      content.type === "html"
+        ? {
+            htmlContent: content.htmlContent,
+            type: "html",
+          }
+        : {
+            meta: content.design,
+            htmlContent: content.htmlContent,
+            type: "unlayer",
+          };
+
     await this.PUT(`/campaigns/${campaignId}/content`, body);
     return { success: true };
   }

--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -56,11 +56,17 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
   async getCampaignContent(campaignId: string): Promise<Result<Content>> {
     const response = await this.GET<any>(`/campaigns/${campaignId}/content`);
 
-    if (!response.data.meta) {
-      throw new Error(
-        `Not implemented: Content responses without 'meta' property are not supported yet.`
-      );
+    if (response.data.type === "html") {
+      return {
+        success: true,
+        value: {
+          htmlContent: response.data.htmlContent,
+          type: "html",
+        },
+      };
     }
+
+    // TODO: validate the type for unlayer design responses
 
     return {
       success: true,

--- a/src/implementations/dummies/html-editor-api-client.tsx
+++ b/src/implementations/dummies/html-editor-api-client.tsx
@@ -12,12 +12,15 @@ export class DummyHtmlEditorApiClient implements HtmlEditorApiClient {
       });
       await timeout(1000);
 
-      const value = createUnlayerContent(campaignId);
+      const value: Content = campaignId.startsWith("html")
+        ? createHtmlContent(campaignId)
+        : createUnlayerContent(campaignId);
 
-      const result: Result<Content> = {
+      const result = {
         success: true,
         value,
-      };
+      } as Result<Content>;
+
       console.log("End getCampaignContent", { result });
       return result;
     };
@@ -47,5 +50,13 @@ function createUnlayerContent(campaignId: string): Content {
     design: design,
     htmlContent: "<html></html>",
     type: "unlayer",
+  };
+}
+
+function createHtmlContent(campaignId: string): Content {
+  const text = `SOY CampaignDesign #${campaignId} ${new Date().getMinutes()}.`;
+  return {
+    htmlContent: `<html><body><div>${text}</div></body></html>`,
+    type: "html",
   };
 }


### PR DESCRIPTION
Hi team! 

These changes add support to HTML templates in our WebApp taking advantage of [Unlayer Legacy Template](https://examples.unlayer.com/web/legacy-template).

Example with the dummy API Client:

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/1157864/152847709-6c09b7b9-84e5-486f-8401-204b4df8bfda.png">

Note: this PR includes commits from #100. So, this PR will be easier to review after merge #100.
