### PR TITLE
Add the property canonicalVersion to generated asset-manifest.json

### DIFF
--- a/cdn-helpers/prepare.sh
+++ b/cdn-helpers/prepare.sh
@@ -176,25 +176,19 @@ mkdir "${ready}" -p
 
 cp -R "${build}/static/." "${ready}/static"
 
-echo "${canonicalTag}" > "${ready}/asset-manifest-${canonicalTag}.txt"
 cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${canonicalTag}.json"
 
 sed -r -i "s/^\\{/\\{\\n  \"canonicalVersion\": \"${canonicalTag}\",/g" "${ready}/asset-manifest-${canonicalTag}.json"
 
 if [ -n "${version}" ]
 then
-  echo "${canonicalTag}" > "${ready}/asset-manifest-${versionMayor}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayor}.json"
-  echo "${canonicalTag}" > "${ready}/versiasset-manifeston-${versionMayorMinor}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinor}.json"
-  echo "${canonicalTag}" > "${ready}/asset-manifest-${versionMayorMinorPatch}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinorPatch}.json"
-  echo "${canonicalTag}" > "${ready}/asset-manifest-${versionMayorMinorPatchPre}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinorPatchPre}.json"
 fi
 
 if [ -n "${name}" ]
 then
-  echo "${canonicalTag}" > "${ready}/asset-manifest-${name}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${name}.json"
 fi

--- a/cdn-helpers/prepare.sh
+++ b/cdn-helpers/prepare.sh
@@ -182,13 +182,13 @@ sed -r -i "s/^\\{/\\{\\n  \"canonicalVersion\": \"${canonicalTag}\",/g" "${ready
 
 if [ -n "${version}" ]
 then
-  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayor}.json"
-  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinor}.json"
-  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinorPatch}.json"
-  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinorPatchPre}.json"
+  cp "${ready}/asset-manifest-${canonicalTag}.json" "${ready}/asset-manifest-${versionMayor}.json"
+  cp "${ready}/asset-manifest-${canonicalTag}.json" "${ready}/asset-manifest-${versionMayorMinor}.json"
+  cp "${ready}/asset-manifest-${canonicalTag}.json" "${ready}/asset-manifest-${versionMayorMinorPatch}.json"
+  cp "${ready}/asset-manifest-${canonicalTag}.json" "${ready}/asset-manifest-${versionMayorMinorPatchPre}.json"
 fi
 
 if [ -n "${name}" ]
 then
-  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${name}.json"
+  cp "${ready}/asset-manifest-${canonicalTag}.json" "${ready}/asset-manifest-${name}.json"
 fi

--- a/cdn-helpers/prepare.sh
+++ b/cdn-helpers/prepare.sh
@@ -179,6 +179,8 @@ cp -R "${build}/static/." "${ready}/static"
 echo "${canonicalTag}" > "${ready}/asset-manifest-${canonicalTag}.txt"
 cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${canonicalTag}.json"
 
+sed -r -i "s/^\\{/\\{\\n  \"canonicalVersion\": \"${canonicalTag}\",/g" "${ready}/asset-manifest-${canonicalTag}.json"
+
 if [ -n "${version}" ]
 then
   echo "${canonicalTag}" > "${ready}/asset-manifest-${versionMayor}.txt"


### PR DESCRIPTION
Hi Team! 

I think that it could be very helpful in the same way that `version.txt` files are with our microservices.

This is the result `asset-manifest.json` file content: 

```diff
 {
+  "canonicalVersion": "v1.1.1_6a6f5ba083b60299154313054536e58a8a922766",
   "files": {
     "main.css": "./static/css/main.93afeb7b.css",
     "main.js": "./static/js/main.a9d11407.js",
     "static/js/787.ef2841bc.chunk.js": "./static/js/787.ef2841bc.chunk.js",
     "static/media/logo.svg": "./static/media/logo.4bdbcf8396881de06a6723a92fed910b.svg",
     "index.html": "./index.html",
     "main.93afeb7b.css.map": "./static/css/main.93afeb7b.css.map",
     "main.a9d11407.js.map": "./static/js/main.a9d11407.js.map",
     "787.ef2841bc.chunk.js.map": "./static/js/787.ef2841bc.chunk.js.map"
   },
   "entrypoints": [
     "static/css/main.93afeb7b.css",
     "static/js/main.a9d11407.js"
   ]
 }
```

Here you have the manifest generated for this PR: https://cdn.fromdoppler.com/editors-webapp/asset-manifest-pr-105.json