### PR TITLE
Remove Preheader Text from the editor

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -100,6 +100,10 @@ export const Editor = ({
     mergeTagsConfig: {
       sort: false,
     },
+    displayMode: "email",
+    features: {
+      preheaderText: false,
+    },
     mergeTags: mergeTags,
     user: user,
     customJS: [

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,12 +1,21 @@
 import { useEffect, useRef, useState } from "react";
-import EmailEditor, { UnlayerOptions, User } from "react-email-editor";
+import EmailEditor, {
+  Features,
+  UnlayerOptions,
+  User,
+} from "react-email-editor";
 import { useGetUserFields } from "../queries/user-fields-queries";
 import { useAppServices } from "./AppServicesContext";
 import { useAppSessionState } from "./AppSessionStateContext";
 import { EditorState } from "./SingletonEditor";
 
 interface ExtendedUnlayerOptions extends UnlayerOptions {
+  features: ExtendedFeatures;
   mergeTagsConfig: { sort: boolean };
+}
+
+interface ExtendedFeatures extends Features {
+  preheaderText?: boolean;
 }
 
 interface ExtendedUnlayerUser extends User {


### PR DESCRIPTION
Hi team!

Doppler allows the user to edit the preheader text before editing the content. So, this should not be visible inside the email content editor.

![image](https://user-images.githubusercontent.com/1157864/153494357-00e93f32-e7c8-41a0-9edb-f393d53c9758.png)

![image](https://user-images.githubusercontent.com/1157864/153494091-f0cf8481-e76b-45b5-b8f7-97ce1d5e820c.png)

