### PR TITLE
Refactor and fix session management

### DIFF
--- a/src/abstractions/app-session/app-session-state-accessor.ts
+++ b/src/abstractions/app-session/app-session-state-accessor.ts
@@ -1,5 +1,5 @@
 import { AppSessionState } from ".";
 
 export type AppSessionStateAccessor = {
-  current: AppSessionState;
+  getCurrentSessionState(): AppSessionState;
 };

--- a/src/abstractions/app-session/app-session-state-monitor.ts
+++ b/src/abstractions/app-session/app-session-state-monitor.ts
@@ -1,6 +1,6 @@
 import { AppSessionState } from ".";
 
 export interface AppSessionStateMonitor {
+  onSessionUpdate: (appSessionState: AppSessionState) => void;
   start(): void;
-  onSessionUpdate(listener: (appSessionState: AppSessionState) => void): void;
 }

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -16,7 +16,7 @@ const notFoundContent = "There's nothing here!";
 
 const baseAppServices = {
   appSessionStateAccessor: {
-    current: {},
+    getCurrentSessionState: () => ({}),
   },
   appConfiguration: {},
   dopplerRestApiClient: {

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -47,13 +47,12 @@ export const AppSessionStateProvider = ({
     useState<SimplifiedAppSessionState>(defaultAppSessionState);
 
   useEffect(() => {
-    appSessionStateMonitor.onSessionUpdate((newValue) =>
+    appSessionStateMonitor.onSessionUpdate = (newValue) =>
       setAppSessionState((prevState) =>
         prevState.status === newValue.status
           ? prevState // When the status does not change, we could assume that the values does not change
           : mapAppSessionStateToSimplifiedAppSessionState(newValue)
-      )
-    );
+      );
   }, [appSessionStateMonitor]);
 
   return (

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -25,8 +25,12 @@ const isTheSameSession: (
   prevState: SimplifiedAppSessionState,
   newValue: AppSessionState
 ) =>
-  // When the status does not change, we could assume that the values does not change
-  prevState.status === newValue.status;
+  newValue.status !== "authenticated"
+    ? prevState.status === newValue.status
+    : newValue.status === prevState.status &&
+      newValue.dopplerAccountName === prevState.dopplerAccountName &&
+      newValue.unlayerUser.id === prevState.unlayerUser.id &&
+      newValue.unlayerUser.signature === prevState.unlayerUser.signature;
 
 const mapAppSessionStateToSimplifiedAppSessionState: (
   appSessionState: AppSessionState

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -53,6 +53,9 @@ export const AppSessionStateProvider = ({
           ? prevState // When the status does not change, we could assume that the values does not change
           : mapAppSessionStateToSimplifiedAppSessionState(newValue)
       );
+    return () => {
+      appSessionStateMonitor.onSessionUpdate = () => {};
+    };
   }, [appSessionStateMonitor]);
 
   return (

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -1,10 +1,4 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import {
   AppSessionState,
   defaultAppSessionState,
@@ -52,23 +46,15 @@ export const AppSessionStateProvider = ({
   const [appSessionState, setAppSessionState] =
     useState<SimplifiedAppSessionState>(defaultAppSessionState);
 
-  const onSessionUpdate = useCallback(
-    (newValue: AppSessionState) => {
-      if (newValue.status === appSessionState.status) {
-        // When the status does not change, we could assume that the values does not change
-        return;
-      }
-
-      setAppSessionState(
-        mapAppSessionStateToSimplifiedAppSessionState(newValue)
-      );
-    },
-    [appSessionState.status]
-  );
-
   useEffect(() => {
-    appSessionStateMonitor.onSessionUpdate(onSessionUpdate);
-  }, [appSessionStateMonitor, onSessionUpdate]);
+    appSessionStateMonitor.onSessionUpdate((newValue) =>
+      setAppSessionState((prevState) =>
+        prevState.status === newValue.status
+          ? prevState // When the status does not change, we could assume that the values does not change
+          : mapAppSessionStateToSimplifiedAppSessionState(newValue)
+      )
+    );
+  }, [appSessionStateMonitor]);
 
   return (
     <AppSessionStateContext.Provider value={appSessionState}>

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -18,6 +18,16 @@ export const AppSessionStateContext = createContext<SimplifiedAppSessionState>(
   defaultAppSessionState
 );
 
+const isTheSameSession: (
+  prevState: SimplifiedAppSessionState,
+  newValue: AppSessionState
+) => boolean = (
+  prevState: SimplifiedAppSessionState,
+  newValue: AppSessionState
+) =>
+  // When the status does not change, we could assume that the values does not change
+  prevState.status === newValue.status;
+
 const mapAppSessionStateToSimplifiedAppSessionState: (
   appSessionState: AppSessionState
 ) => SimplifiedAppSessionState = (appSessionState: AppSessionState) => {
@@ -49,8 +59,8 @@ export const AppSessionStateProvider = ({
   useEffect(() => {
     appSessionStateMonitor.onSessionUpdate = (newValue) =>
       setAppSessionState((prevState) =>
-        prevState.status === newValue.status
-          ? prevState // When the status does not change, we could assume that the values does not change
+        isTheSameSession(prevState, newValue)
+          ? prevState
           : mapAppSessionStateToSimplifiedAppSessionState(newValue)
       );
     return () => {

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -7,9 +7,9 @@ import React, {
 } from "react";
 import {
   AppSessionState,
-  AppSessionStateMonitor,
   defaultAppSessionState,
 } from "../abstractions/app-session";
+import { useAppServices } from "./AppServicesContext";
 
 type SimplifiedAppSessionState =
   | { status: "unknown" }
@@ -26,11 +26,11 @@ export const AppSessionStateContext = createContext<SimplifiedAppSessionState>(
 
 export const AppSessionStateProvider = ({
   children,
-  appSessionStateMonitor,
 }: {
   children: React.ReactNode;
-  appSessionStateMonitor: AppSessionStateMonitor;
 }) => {
+  const { appSessionStateMonitor } = useAppServices();
+
   const [appSessionState, setAppSessionState] =
     useState<SimplifiedAppSessionState>(defaultAppSessionState);
 

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -55,10 +55,12 @@ export const AppSessionStateProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { appSessionStateMonitor } = useAppServices();
+  const { appSessionStateMonitor, appSessionStateAccessor } = useAppServices();
 
   const [appSessionState, setAppSessionState] =
-    useState<SimplifiedAppSessionState>(defaultAppSessionState);
+    useState<SimplifiedAppSessionState>(
+      appSessionStateAccessor.getCurrentSessionState()
+    );
 
   useEffect(() => {
     appSessionStateMonitor.onSessionUpdate = (newValue) =>

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -24,6 +24,24 @@ export const AppSessionStateContext = createContext<SimplifiedAppSessionState>(
   defaultAppSessionState
 );
 
+const mapAppSessionStateToSimplifiedAppSessionState: (
+  appSessionState: AppSessionState
+) => SimplifiedAppSessionState = (appSessionState: AppSessionState) => {
+  if (appSessionState.status !== "authenticated") {
+    return { status: appSessionState.status };
+  }
+  const {
+    status,
+    dopplerAccountName,
+    unlayerUser: { id, signature },
+  } = appSessionState;
+  return {
+    status,
+    dopplerAccountName,
+    unlayerUser: { id, signature },
+  };
+};
+
 export const AppSessionStateProvider = ({
   children,
 }: {
@@ -41,21 +59,9 @@ export const AppSessionStateProvider = ({
         return;
       }
 
-      if (newValue.status === "authenticated") {
-        const {
-          status,
-          dopplerAccountName,
-          unlayerUser: { id, signature },
-        } = newValue;
-        setAppSessionState({
-          status,
-          dopplerAccountName,
-          unlayerUser: { id, signature },
-        });
-      } else {
-        const { status } = newValue;
-        setAppSessionState({ status });
-      }
+      setAppSessionState(
+        mapAppSessionStateToSimplifiedAppSessionState(newValue)
+      );
     },
     [appSessionState.status]
   );

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -16,7 +16,7 @@ import {
 
 const baseAppServices = {
   appSessionStateAccessor: {
-    current: {
+    getCurrentSessionState: () => ({
       status: "authenticated",
       jwtToken: "jwtToken",
       dopplerAccountName: "dopplerAccountName",
@@ -24,7 +24,7 @@ const baseAppServices = {
         id: "unlayerUserId",
         signature: "unlayerUserSignature",
       },
-    },
+    }),
   },
   appConfiguration: {
     unlayerProjectId: 12345,

--- a/src/components/Editor.test.tsx
+++ b/src/components/Editor.test.tsx
@@ -56,7 +56,7 @@ describe(Editor.name, () => {
         loaderUrl,
       },
       appSessionStateAccessor: {
-        current: authenticatedSession,
+        getCurrentSessionState: () => authenticatedSession,
       },
       dopplerRestApiClient: {
         getFields: () =>
@@ -115,9 +115,9 @@ describe(Editor.name, () => {
           loaderUrl,
         },
         appSessionStateAccessor: {
-          current: {
+          getCurrentSessionState: () => ({
             status: sessionStatus,
-          },
+          }),
         },
         dopplerRestApiClient: {
           getFields: () =>

--- a/src/components/Main.test.tsx
+++ b/src/components/Main.test.tsx
@@ -8,7 +8,7 @@ import { Main, mainTestId } from "./Main";
 
 const baseAppServices = {
   appSessionStateAccessor: {
-    current: {},
+    getCurrentSessionState: () => ({}),
   },
   appConfiguration: {},
   dopplerRestApiClient: {

--- a/src/components/SessionDemo.tsx
+++ b/src/components/SessionDemo.tsx
@@ -13,7 +13,7 @@ export const SessionDemo = () => {
           SimplifiedSessionState from context: {JSON.stringify(sessionState)}
           <br />
           SessionState from AppServices:{" "}
-          {JSON.stringify(appSessionStateAccessor.current)}
+          {JSON.stringify(appSessionStateAccessor.getCurrentSessionState())}
         </pre>
       </code>
       <p>

--- a/src/components/SingletonEditor.test.tsx
+++ b/src/components/SingletonEditor.test.tsx
@@ -17,13 +17,13 @@ const defaultAppServices = {
     loaderUrl: "loaderUrl",
   },
   appSessionStateAccessor: {
-    current: {
+    getCurrentSessionState: () => ({
       status: "authenticated",
       unlayerUser: {
         id: "unlayerUserId",
         signature: "unlayerUserSignature",
       },
-    },
+    }),
   },
   dopplerRestApiClient: {
     getFields: () => Promise.resolve({ success: true, value: [] as Field[] }),

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -5,6 +5,7 @@ import { AppConfigurationRendererImplementation } from "./implementations/app-co
 import {
   //
   PollingAppSessionStateMonitor,
+  WrapperAppSessionStateAccessor,
 } from "./implementations/app-session/polling-app-session-state-monitor";
 import {
   ServicesFactories,
@@ -57,7 +58,8 @@ export const configureApp = (
         appSessionStateAccessor,
         appConfiguration,
       }),
-    appSessionStateAccessorFactory: () => appSessionStateWrapper,
+    appSessionStateAccessorFactory: () =>
+      new WrapperAppSessionStateAccessor({ appSessionStateWrapper }),
     appSessionStateMonitorFactory: (appServices: AppServices) =>
       new PollingAppSessionStateMonitor({
         appSessionStateWrapper,

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -4,8 +4,8 @@ import { defaultAppSessionState } from "./abstractions/app-session/app-session-s
 import { AppConfigurationRendererImplementation } from "./implementations/app-configuration-renderer";
 import {
   //
-  PullingAppSessionStateMonitor,
-} from "./implementations/app-session/pulling-app-session-state-monitor";
+  PollingAppSessionStateMonitor,
+} from "./implementations/app-session/polling-app-session-state-monitor";
 import {
   ServicesFactories,
   SingletonLazyAppServicesContainer,
@@ -59,7 +59,7 @@ export const configureApp = (
       }),
     appSessionStateAccessorFactory: () => appSessionStateWrapper,
     appSessionStateMonitorFactory: (appServices: AppServices) =>
-      new PullingAppSessionStateMonitor({
+      new PollingAppSessionStateMonitor({
         appSessionStateWrapper,
         appServices,
       }),

--- a/src/implementations/DopplerRestApiClientImpl.test.ts
+++ b/src/implementations/DopplerRestApiClientImpl.test.ts
@@ -18,7 +18,7 @@ describe(DopplerRestApiClientImpl.name, () => {
       };
 
       const appSessionStateAccessor = {
-        current: authenticatedSession,
+        getCurrentSessionState: () => authenticatedSession,
       } as AppSessionStateAccessor;
 
       const field1Name = "field1";
@@ -131,11 +131,11 @@ describe(DopplerRestApiClientImpl.name, () => {
       // Arrange
       const error = new Error("Network error");
       const appSessionStateAccessor = {
-        current: {
+        getCurrentSessionState: () => ({
           status: "authenticated",
           jwtToken: "jwtToken",
           dopplerAccountName: "dopplerAccountName",
-        },
+        }),
       } as AppSessionStateAccessor;
 
       const appConfiguration = {
@@ -170,9 +170,9 @@ describe(DopplerRestApiClientImpl.name, () => {
       async ({ sessionStatus }) => {
         // Arrange
         const appSessionStateAccessor = {
-          current: {
+          getCurrentSessionState: () => ({
             status: sessionStatus,
-          },
+          }),
         } as AppSessionStateAccessor;
 
         const appConfiguration = {

--- a/src/implementations/DopplerRestApiClientImpl.ts
+++ b/src/implementations/DopplerRestApiClientImpl.ts
@@ -27,7 +27,8 @@ export class DopplerRestApiClientImpl implements DopplerRestApiClient {
   }
 
   private getConnectionData() {
-    const connectionData = this.appSessionStateAccessor.current;
+    const connectionData =
+      this.appSessionStateAccessor.getCurrentSessionState();
     if (connectionData.status !== "authenticated") {
       throw new Error("Authenticated session required");
     }

--- a/src/implementations/HtmlEditorApiClientImpl.test.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.test.ts
@@ -21,7 +21,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
       };
 
       const appSessionStateAccessor = {
-        current: authenticatedSession,
+        getCurrentSessionState: () => authenticatedSession,
       } as AppSessionStateAccessor;
 
       const htmlContent = "<html></html>";
@@ -98,7 +98,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
       };
 
       const appSessionStateAccessor = {
-        current: authenticatedSession,
+        getCurrentSessionState: () => authenticatedSession,
       } as AppSessionStateAccessor;
 
       const htmlContent = "<html></html>";
@@ -158,11 +158,11 @@ describe(HtmlEditorApiClientImpl.name, () => {
       // Arrange
       const error = new Error("Network error");
       const appSessionStateAccessor = {
-        current: {
+        getCurrentSessionState: () => ({
           status: "authenticated",
           jwtToken: "jwtToken",
           dopplerAccountName: "dopplerAccountName",
-        },
+        }),
       } as AppSessionStateAccessor;
 
       const appConfiguration = {
@@ -197,9 +197,9 @@ describe(HtmlEditorApiClientImpl.name, () => {
       async ({ sessionStatus }) => {
         // Arrange
         const appSessionStateAccessor = {
-          current: {
+          getCurrentSessionState: () => ({
             status: sessionStatus,
-          },
+          }),
         } as AppSessionStateAccessor;
 
         const appConfiguration = {
@@ -247,7 +247,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
       };
 
       const appSessionStateAccessor = {
-        current: authenticatedSession,
+        getCurrentSessionState: () => authenticatedSession,
       } as AppSessionStateAccessor;
 
       const design = { testContent: "test content" } as unknown as Design;
@@ -316,7 +316,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
       };
 
       const appSessionStateAccessor = {
-        current: authenticatedSession,
+        getCurrentSessionState: () => authenticatedSession,
       } as AppSessionStateAccessor;
 
       const htmlContent = "<html></html>";

--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -25,7 +25,8 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
   }
 
   private getConnectionData() {
-    const connectionData = this.appSessionStateAccessor.current;
+    const connectionData =
+      this.appSessionStateAccessor.getCurrentSessionState();
     if (connectionData.status !== "authenticated") {
       throw new Error("Authenticated session required");
     }

--- a/src/implementations/app-session/polling-app-session-state-monitor.ts
+++ b/src/implementations/app-session/polling-app-session-state-monitor.ts
@@ -8,7 +8,7 @@ import {
 
 const SESSION_STATE_UPDATE = Symbol("SESSION_STATE_UPDATE");
 
-export class PullingAppSessionStateMonitor implements AppSessionStateMonitor {
+export class PollingAppSessionStateMonitor implements AppSessionStateMonitor {
   private readonly _appSessionStateWrapper;
   private readonly _window;
   private readonly _dopplerLegacyClient;

--- a/src/implementations/app-session/polling-app-session-state-monitor.ts
+++ b/src/implementations/app-session/polling-app-session-state-monitor.ts
@@ -1,9 +1,30 @@
 import { AppServices } from "../../abstractions";
 import {
   AppSessionState,
+  AppSessionStateAccessor,
   AppSessionStateMonitor,
   defaultAppSessionState,
 } from "../../abstractions/app-session";
+
+interface AppSessionStateWrapper {
+  current: AppSessionState;
+}
+
+export class WrapperAppSessionStateAccessor implements AppSessionStateAccessor {
+  private readonly _appSessionStateWrapper;
+
+  constructor({
+    appSessionStateWrapper,
+  }: {
+    appSessionStateWrapper: AppSessionStateWrapper;
+  }) {
+    this._appSessionStateWrapper = appSessionStateWrapper;
+  }
+
+  getCurrentSessionState(): AppSessionState {
+    return this._appSessionStateWrapper.current;
+  }
+}
 
 export class PollingAppSessionStateMonitor implements AppSessionStateMonitor {
   private readonly _appSessionStateWrapper;
@@ -21,7 +42,7 @@ export class PollingAppSessionStateMonitor implements AppSessionStateMonitor {
       appConfiguration: { keepAliveMilliseconds },
     },
   }: {
-    appSessionStateWrapper: { current: AppSessionState };
+    appSessionStateWrapper: AppSessionStateWrapper;
     appServices: AppServices;
   }) {
     this._appSessionStateWrapper = appSessionStateWrapper;

--- a/src/implementations/app-session/polling-app-session-state-monitor.ts
+++ b/src/implementations/app-session/polling-app-session-state-monitor.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "events";
 import { AppServices } from "../../abstractions";
 import {
   AppSessionState,
@@ -6,14 +5,13 @@ import {
   defaultAppSessionState,
 } from "../../abstractions/app-session";
 
-const SESSION_STATE_UPDATE = Symbol("SESSION_STATE_UPDATE");
-
 export class PollingAppSessionStateMonitor implements AppSessionStateMonitor {
   private readonly _appSessionStateWrapper;
   private readonly _window;
   private readonly _dopplerLegacyClient;
-  private readonly _eventEmitter = new EventEmitter();
   private readonly _keepAliveMilliseconds;
+
+  public onSessionUpdate: (sessionState: AppSessionState) => void = () => {};
 
   constructor({
     appSessionStateWrapper,
@@ -34,7 +32,7 @@ export class PollingAppSessionStateMonitor implements AppSessionStateMonitor {
 
   private updateAndEmit(appSessionState: AppSessionState): void {
     this._appSessionStateWrapper.current = appSessionState;
-    this._eventEmitter.emit(SESSION_STATE_UPDATE, appSessionState);
+    this.onSessionUpdate(appSessionState);
   }
 
   private async fetchDopplerUserData(): Promise<AppSessionState> {
@@ -55,9 +53,5 @@ export class PollingAppSessionStateMonitor implements AppSessionStateMonitor {
       this.updateAndEmit(await this.fetchDopplerUserData());
     }, this._keepAliveMilliseconds);
     this.updateAndEmit(await this.fetchDopplerUserData());
-  }
-
-  onSessionUpdate(listener: (appSessionState: AppSessionState) => void): void {
-    this._eventEmitter.on(SESSION_STATE_UPDATE, listener);
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,9 +24,7 @@ render(
     <QueryClientProvider client={queryClient}>
       <BrowserRouter basename={appServices.appConfiguration.basename}>
         <AppServicesProvider appServices={appServices}>
-          <AppSessionStateProvider
-            appSessionStateMonitor={appSessionStateMonitor}
-          >
+          <AppSessionStateProvider>
             <App />
           </AppSessionStateProvider>
         </AppServicesProvider>

--- a/src/queries/user-fields-queries.tsx
+++ b/src/queries/user-fields-queries.tsx
@@ -10,13 +10,13 @@ type GetUserFieldsQueryKey = {
 }[];
 
 export const useGetUserFields = () => {
-  const {
-    dopplerRestApiClient,
-    appSessionStateAccessor: { current },
-  } = useAppServices();
+  const { dopplerRestApiClient, appSessionStateAccessor } = useAppServices();
 
+  const currentSessionState = appSessionStateAccessor.getCurrentSessionState();
   const dopplerAccountName =
-    current.status === "authenticated" ? current.dopplerAccountName : null;
+    currentSessionState.status === "authenticated"
+      ? currentSessionState.dopplerAccountName
+      : null;
 
   const queryKey: GetUserFieldsQueryKey = [
     {


### PR DESCRIPTION
Working on an independent micro-frontend to deal with Doppler session management (see https://github.com/FromDoppler/doppler-session-mfe/pull/7), I found that we were messing it using the same object to represent the session wrapper (only useful on current session management implementation) and the session state accessor.

Also, there were some minor issues that, at the moment do not affect us, but they will if we improve the session management, for example using a cache.

The PR is XL, but I made it commit by commit, so, I think that it should be easy to follow.

Pending:
- [x] Test in a real environment
