### PR TITLE
[DE-539] obtener sesión desde la información de usuario

### DIFF
--- a/src/abstractions/app-session/app-session-state.ts
+++ b/src/abstractions/app-session/app-session-state.ts
@@ -3,6 +3,7 @@ export type AuthenticatedAppSessionState = {
   jwtToken: string;
   dopplerAccountName: string;
   unlayerUser: { id: string; signature: string };
+  lang: "en" | "es";
 };
 
 export type AppSessionState =

--- a/src/components/AppServicesContext.test.tsx
+++ b/src/components/AppServicesContext.test.tsx
@@ -133,49 +133,6 @@ describe(useAppServices.name, () => {
     );
   };
 
-  it("should inject service with dependencies into a component and do not create other services", () => {
-    // Arrange
-    const {
-      appServices,
-      configurationAsJson,
-      windowFactory,
-      appConfigurationFactory,
-    } = buildTestScenario();
-
-    // Act
-    render(
-      <AppServicesProvider appServices={appServices}>
-        <HookInjectedDemoComponent />
-      </AppServicesProvider>
-    );
-
-    // Assert
-    const renderResult = screen.getByTestId(resultElementTestId);
-    expect(renderResult.textContent).toBe(configurationAsJson);
-    expect(windowFactory).not.toHaveBeenCalled();
-    expect(appConfigurationFactory).toHaveBeenCalled();
-  });
-
-  it("should not inject service defined in a different context", () => {
-    // Arrange
-    const { appServices, appConfigurationFactory } = buildTestScenario();
-
-    // Act
-    render(
-      <div>
-        <AppServicesProvider appServices={appServices}>
-          <div></div>
-        </AppServicesProvider>
-        <HookInjectedDemoComponent />
-      </div>
-    );
-
-    // Assert
-    const renderResult = screen.getByTestId(resultElementTestId);
-    expect(renderResult).toBeEmptyDOMElement();
-    expect(appConfigurationFactory).not.toHaveBeenCalled();
-  });
-
   it("should NOT make honor to explicit injected appServices", () => {
     // Arrange
     const { appServices, appConfigurationFactory } = buildTestScenario();

--- a/src/components/AppSessionStateContext.test.tsx
+++ b/src/components/AppSessionStateContext.test.tsx
@@ -1,0 +1,71 @@
+import { act, render } from "@testing-library/react";
+import {
+  AppSessionStateProvider,
+  useAppSessionState,
+} from "./AppSessionStateContext";
+import { AppServicesProvider } from "./AppServicesContext";
+import { AppServices } from "../abstractions";
+import {
+  AppSessionState,
+  AppSessionStateMonitor,
+} from "../abstractions/app-session";
+
+const expectedLang = "en";
+const UNKNOWN_SESSION: AppSessionState = {
+  status: "unknown",
+};
+const NON_AUTHENTICATED: AppSessionState = {
+  status: "non-authenticated",
+};
+const AUTHENTICATED: AppSessionState = {
+  lang: expectedLang,
+  status: "authenticated",
+  jwtToken: "jwt",
+  unlayerUser: {
+    id: "000",
+    signature: "000",
+  },
+  dopplerAccountName: "doppler_mock@mail.com",
+};
+
+const appSessionStateMonitor: AppSessionStateMonitor = {
+  onSessionUpdate: () => null,
+  start: () => {},
+};
+
+const appServices: AppServices = {
+  appSessionStateMonitor,
+  appSessionStateAccessor: {
+    getCurrentSessionState: (): AppSessionState => UNKNOWN_SESSION,
+  },
+} as unknown as AppServices;
+
+// Use to check the currentStateSession
+let currentStateSession: any;
+const ChildrenComponent = () => {
+  currentStateSession = useAppSessionState();
+  return <></>;
+};
+
+render(
+  <AppServicesProvider appServices={appServices}>
+    <AppSessionStateProvider>
+      <ChildrenComponent />
+    </AppSessionStateProvider>
+  </AppServicesProvider>
+);
+
+it("should update the session state context", () => {
+  expect(currentStateSession).toEqual(UNKNOWN_SESSION);
+  act(() => {
+    appSessionStateMonitor.onSessionUpdate(NON_AUTHENTICATED);
+  });
+  expect(currentStateSession).toEqual(NON_AUTHENTICATED);
+
+  act(() => {
+    appSessionStateMonitor.onSessionUpdate(AUTHENTICATED);
+  });
+  expect(currentStateSession.jwtToken).toBeUndefined();
+  expect(currentStateSession.status).toEqual(AUTHENTICATED.status);
+  expect(currentStateSession.lang).toEqual(AUTHENTICATED.lang);
+});

--- a/src/components/AppSessionStateContext.tsx
+++ b/src/components/AppSessionStateContext.tsx
@@ -12,6 +12,7 @@ type SimplifiedAppSessionState =
       status: "authenticated";
       dopplerAccountName: string;
       unlayerUser: { id: string; signature: string };
+      lang: "en" | "es";
     };
 
 export const AppSessionStateContext = createContext<SimplifiedAppSessionState>(
@@ -42,11 +43,13 @@ const mapAppSessionStateToSimplifiedAppSessionState: (
     status,
     dopplerAccountName,
     unlayerUser: { id, signature },
+    lang,
   } = appSessionState;
   return {
     status,
     dopplerAccountName,
     unlayerUser: { id, signature },
+    lang,
   };
 };
 

--- a/src/components/Editor.test.tsx
+++ b/src/components/Editor.test.tsx
@@ -35,6 +35,7 @@ const authenticatedSession: AuthenticatedAppSessionState = {
     id: unlayerUserId,
     signature: unlayerUserSignature,
   },
+  lang: "en",
 };
 
 const queryClient = new QueryClient({

--- a/src/components/RequireAuth.test.tsx
+++ b/src/components/RequireAuth.test.tsx
@@ -47,6 +47,7 @@ describe(RequireAuth.name, () => {
             status: "authenticated",
             dopplerAccountName: "me@me.com",
             unlayerUser: { id: "id", signature: "signature" },
+            lang: "en",
           }}
         >
           <RequireAuth>

--- a/src/implementations/app-session/doppler-mfe-app-session-state-monitor.ts
+++ b/src/implementations/app-session/doppler-mfe-app-session-state-monitor.ts
@@ -14,6 +14,7 @@ type AuthenticatedDopplerSessionMfeState = {
   dopplerAccountName: string;
   unlayerUserId: string;
   unlayerUserSignature: string;
+  lang: "en" | "es";
 };
 
 type DopplerSessionMfeState =
@@ -38,6 +39,7 @@ const mapDopplerSessionState: (
         status: "authenticated",
         jwtToken: dopplerSessionState.jwtToken,
         dopplerAccountName: dopplerSessionState.dopplerAccountName,
+        lang: dopplerSessionState.lang,
         unlayerUser: {
           id: dopplerSessionState.unlayerUserId,
           signature: dopplerSessionState.unlayerUserSignature,


### PR DESCRIPTION
Ahora en el `AppSessionStateContext` tenemos el valor de _lang_ obtenido en la información de la sesión

- [x] Agregar el lenguaje del usuario al estado de la sesión
- [x] Actualizar pruebas