### PR TITLE
[DE-580] Refactorizar hook useSingletonEditor

### DIFF
--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -10,6 +10,7 @@ import { Header } from "./Header";
 import { EditorBottomBar } from "./EditorBottomBar";
 import { useIntl } from "react-intl";
 import { useAppServices } from "./AppServicesContext";
+import { Content } from "../abstractions/domain/content";
 
 export const loadingMessageTestId = "loading-message";
 export const errorMessageTestId = "error-message";
@@ -28,11 +29,10 @@ export const Campaign = () => {
 
   const campaignContentQuery = useGetCampaignContent(idCampaign);
   const campaignContentMutation = useUpdateCampaignContent();
-  const { getContent, save } = useSingletonEditor(
+  const { save } = useSingletonEditor(
     {
       initialContent: campaignContentQuery.data,
-      onSave: async () => {
-        const content = await getContent();
+      onSave: async (content: Content) => {
         campaignContentMutation.mutate({ idCampaign, content });
       },
     }

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -29,14 +29,12 @@ export const Campaign = () => {
 
   const campaignContentQuery = useGetCampaignContent(idCampaign);
   const campaignContentMutation = useUpdateCampaignContent();
-  const { save } = useSingletonEditor(
-    {
-      initialContent: campaignContentQuery.data,
-      onSave: async (content: Content) => {
-        campaignContentMutation.mutate({ idCampaign, content });
-      },
-    }
-  );
+  const { save } = useSingletonEditor({
+    initialContent: campaignContentQuery.data,
+    onSave: async (content: Content) => {
+      campaignContentMutation.mutate({ idCampaign, content });
+    },
+  });
 
   const intl = useIntl();
 

--- a/src/components/SingletonEditor.test.tsx
+++ b/src/components/SingletonEditor.test.tsx
@@ -6,7 +6,34 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { Field } from "../abstractions/doppler-rest-api-client";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
 import { Content } from "../abstractions/domain/content";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+const DoubleEditor = ({ setEditorState, hidden, ...otherProps }: any) => {
+  useEffect(() => {
+    setEditorState({
+      unlayer: {
+        loadDesign: jest.fn(),
+        exportHtml: (cb: any) => {
+          cb({
+            design: {},
+            html: "",
+          });
+        },
+      },
+      isLoaded: true,
+    });
+  }, []);
+
+  const containerStyle = {
+    height: "100%",
+    display: hidden ? "none" : "flex",
+  };
+  return <div style={containerStyle} {...otherProps} />;
+};
+
+jest.mock("./Editor", () => {
+  return { Editor: DoubleEditor };
+});
 
 const singletonEditorTestId = "singleton-editor-test";
 

--- a/src/components/SingletonEditor.test.tsx
+++ b/src/components/SingletonEditor.test.tsx
@@ -54,11 +54,12 @@ describe(`${SingletonEditorProvider.name}`, () => {
   // Arrange
   const appServices = defaultAppServices as AppServices;
 
-  const DemoComponent = () => {
-    const [initialContent, setInitialContent] = useState<Content | undefined>(
-      undefined
-    );
-    useSingletonEditor({ initialContent, onSave: () => {} });
+  const DemoComponent = ({ onSave }: { onSave: () => void }) => {
+    const [initialContent, setInitialContent] = useState<Content | undefined>();
+    const { save } = useSingletonEditor({
+      initialContent,
+      onSave,
+    });
 
     const changeInitialContent = () => {
       setInitialContent(generateNewContent());
@@ -67,6 +68,7 @@ describe(`${SingletonEditorProvider.name}`, () => {
     return (
       <>
         <button onClick={changeInitialContent}>change initial content</button>
+        <button onClick={save}>save content</button>
       </>
     );
   };
@@ -87,7 +89,7 @@ describe(`${SingletonEditorProvider.name}`, () => {
     // Act
     render(
       <WrapperSingletonProviderTest>
-        <DemoComponent />
+        <DemoComponent onSave={() => {}} />
       </WrapperSingletonProviderTest>
     );
     // Assert
@@ -99,7 +101,7 @@ describe(`${SingletonEditorProvider.name}`, () => {
     // Act
     render(
       <WrapperSingletonProviderTest>
-        <DemoComponent />
+        <DemoComponent onSave={() => {}} />
       </WrapperSingletonProviderTest>
     );
     const loadInitialContentBtn = screen.getByText("change initial content");
@@ -109,5 +111,24 @@ describe(`${SingletonEditorProvider.name}`, () => {
     // Assert
     const editorEl = screen.getByTestId(singletonEditorTestId);
     expect(editorEl.style.display).toBe("flex");
+  });
+
+  it("should save content when save event is fire", () => {
+    // Arrange
+    const onSaveFn = jest.fn();
+    // Act
+    render(
+      <WrapperSingletonProviderTest>
+        <DemoComponent onSave={onSaveFn} />
+      </WrapperSingletonProviderTest>
+    );
+    const changeInitialContentBtn = screen.getByText("change initial content");
+    act(() => {
+      changeInitialContentBtn.click();
+    });
+    const buttonSave = screen.getByText("save content");
+    buttonSave.click();
+    // Assert
+    expect(onSaveFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -30,9 +30,10 @@ export const SingletonDesignContext = createContext<ISingletonDesignContext>({
   editorState: { isLoaded: false, unlayer: undefined },
 });
 
-export const useSingletonEditor = (
-  { initialContent, onSave }: UseSingletonEditorConfig
-) => {
+export const useSingletonEditor = ({
+  initialContent,
+  onSave,
+}: UseSingletonEditorConfig) => {
   const { editorState, setContent } = useContext(SingletonDesignContext);
 
   const saveHandler = () => {

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import { Editor } from "./Editor";
 import EmailEditor, { HtmlExport } from "react-email-editor";
 import { Content } from "../abstractions/domain/content";
@@ -10,7 +10,7 @@ export type EditorState =
 interface ISingletonDesignContext {
   hidden: boolean;
   setContent: (c: Content | undefined) => void;
-  getContent: () => Promise<Content>;
+  editorState: EditorState;
 }
 
 export const emptyDesign = {
@@ -21,27 +21,41 @@ export const emptyDesign = {
 
 interface UseSingletonEditorConfig {
   initialContent: Content | undefined;
-  onSave: () => void;
+  onSave: (content: Content) => void;
 }
 
 export const SingletonDesignContext = createContext<ISingletonDesignContext>({
   hidden: true,
   setContent: () => {},
-  getContent: () =>
-    Promise.resolve({
-      design: emptyDesign,
-      htmlContent: "",
-      type: "unlayer",
-    } as Content),
+  editorState: { isLoaded: false, unlayer: undefined },
 });
 
 export const useSingletonEditor = (
   { initialContent, onSave }: UseSingletonEditorConfig
 ) => {
-  const {
-    getContent,
-    setContent,
-  } = useContext(SingletonDesignContext);
+  const { editorState, setContent } = useContext(SingletonDesignContext);
+
+  const saveHandler = () => {
+    if (!editorState.isLoaded) {
+      console.error("The editor is loading, can't save yet!");
+      return;
+    }
+
+    editorState.unlayer.exportHtml((htmlExport: HtmlExport) => {
+      const content = !htmlExport.design
+        ? {
+            htmlContent: htmlExport.html,
+            type: "html",
+          }
+        : {
+            design: htmlExport.design,
+            htmlContent: htmlExport.html,
+            type: "unlayer",
+          };
+
+      onSave(content as Content);
+    });
+  };
 
   useEffect(() => {
     setContent(initialContent);
@@ -50,7 +64,7 @@ export const useSingletonEditor = (
     };
   }, [initialContent, setContent]);
 
-  return { getContent, save: onSave };
+  return { save: saveHandler };
 };
 
 export const SingletonEditorProvider = ({
@@ -65,34 +79,6 @@ export const SingletonEditorProvider = ({
     unlayer: undefined,
     isLoaded: false,
   });
-
-  const getContent = () => {
-    if (!editorState.isLoaded) {
-      const fallbackResult: Content = {
-        design: emptyDesign,
-        htmlContent: "",
-        type: "unlayer",
-      };
-      return Promise.resolve(fallbackResult);
-    }
-    return new Promise<Content>((resolve) => {
-      editorState.unlayer.exportHtml((htmlExport: HtmlExport) => {
-        if (!htmlExport.design) {
-          // It is a legacy template: https://examples.unlayer.com/web/legacy-template
-          resolve({
-            htmlContent: htmlExport.html,
-            type: "html",
-          });
-        } else {
-          resolve({
-            design: htmlExport.design,
-            htmlContent: htmlExport.html,
-            type: "unlayer",
-          });
-        }
-      });
-    });
-  };
 
   useEffect(() => {
     if (editorState.isLoaded) {
@@ -131,7 +117,7 @@ export const SingletonEditorProvider = ({
   const defaultContext: ISingletonDesignContext = {
     hidden,
     setContent,
-    getContent,
+    editorState,
   };
 
   return (


### PR DESCRIPTION
El objetivo es cambiar el comportamiento de `useSingletonEditor` para que permita configurar el editor y abstraer la lógica de _unMount_ que antes se encontraba en _/campaign_