### PR TITLE
Debug with VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug CRA Tests",
+        "type": "node",
+        "request": "launch",
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
+        "args": ["test", "--runInBand", "--no-cache", "--watchAll=false"],
+        "cwd": "${workspaceRoot}",
+        "protocol": "inspector",
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "env": { "CI": "true" },
+        "disableOptimisticBPs": true
+      }
+    ]
+  }
+  

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,19 @@
         "internalConsoleOptions": "neverOpen",
         "env": { "CI": "true" },
         "disableOptimisticBPs": true
+      },
+      {
+        "name": "Single Test",
+        "type": "node",
+        "request": "launch",
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
+        "args": ["test", "--runInBand", "--no-cache", "--watchAll=false", "--testNamePattern=\"should show and hide EmailEditor when design is set and unset\""],
+        "cwd": "${workspaceRoot}",
+        "protocol": "inspector",
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "env": { "CI": "true" },
+        "disableOptimisticBPs": true
       }
     ]
   }

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -205,7 +205,7 @@ describe(Campaign.name, () => {
     // Assert
     const saveBtn = await screen.findByText("Guardar");
 
-    await userEvent.click(saveBtn);
+    act(() => saveBtn.click());
 
     await waitFor(() => {
       expect(updateCampaignContent).toHaveBeenCalledWith(idCampaign, {

--- a/src/components/EditorTopBar.test.tsx
+++ b/src/components/EditorTopBar.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { act } from "react-dom/test-utils";
 import { AppServicesProvider } from "./AppServicesContext";
 import { EditorTopBar } from "./EditorTopBar";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
@@ -46,7 +46,7 @@ describe(EditorTopBar.name, () => {
     expect(screen.getByText("home")).toBeNull;
 
     // Act
-    userEvent.click(screen.getByText("exit_editor"));
+    act(() => screen.getByText("exit_editor").click());
 
     // Assert
     expect(screen.queryByText("home")).not.toBeNull;
@@ -65,7 +65,7 @@ describe(EditorTopBar.name, () => {
       </AppServicesProvider>
     );
 
-    userEvent.click(screen.getByText("exit_editor"));
+    act(() => screen.getByText("exit_editor").click());
 
     const homeOption = screen.getByText("home");
     const campaignsOption = screen.getByText("campaigns");

--- a/src/components/SingletonEditor.test.tsx
+++ b/src/components/SingletonEditor.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { AppServices } from "../abstractions";
 import { Editor } from "./Editor";
 import { SingletonEditorProvider, useSingletonEditor } from "./SingletonEditor";
@@ -8,6 +7,7 @@ import { Design } from "react-email-editor";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { Field } from "../abstractions/doppler-rest-api-client";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
+import { act } from "react-dom/test-utils";
 
 const singletonEditorTestId = "singleton-editor-test";
 
@@ -86,13 +86,13 @@ describe(Editor.name, () => {
 
     // Shown when a design is loaded
     // Act
-    await userEvent.click(screen.getByText("LoadDesign"));
+    act(() => screen.getByText("LoadDesign").click());
     // Assert
     expect(editorEl.style.display).toBe("flex");
 
     // Hidden when the design is unloaded
     // Act
-    await userEvent.click(screen.getByText("UnloadDesign"));
+    act(() => screen.getByText("UnloadDesign").click());
     // Assert
     expect(editorEl.style.display).toBe("none");
   });


### PR DESCRIPTION
Hi team!

It is to allow us to easily debug the tests with VS Code.

If you want to run only one test, you can edit the file `.vscode/launch.json` updating `--testNamePattern`.

<img width="1377" alt="image" src="https://user-images.githubusercontent.com/1157864/164763981-65a1f67d-c8d8-4f9f-9425-f7da21e22dd1.png">

I had to also change the usage of `userEvent.click(el)` by `act(() => el.click())` because it was not working fine with the debugger (I googled it but I did not find anything).

<img width="1767" alt="image" src="https://user-images.githubusercontent.com/1157864/164764328-1bb51488-792d-4bb4-a835-2e87e585a48e.png">

Could you review it?