### PR TITLE
chore: update yarn test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,8 @@
     "prettier-fix": "prettier --write \"**/**\"",
     "prettier-check": "prettier --check \"**/**\"",
     "start": "react-scripts start",
-    "build": "react-scripts --openssl-legacy-provider build",
-    "test": "react-scripts --openssl-legacy-provider test",
-    "test-dev": "react-scripts test",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
The flag `--openssl-legacy-provider` isn't working in all local environments.