### PR TITLE
[DE-583] habilitar pruebas comentadas por error con el uso de portal

### DIFF
--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -16,7 +16,7 @@ export type EditorState =
   | { isLoaded: false; unlayer: undefined }
   | { isLoaded: true; unlayer: UnlayerEditor };
 
-interface ISingletonDesignContext {
+export interface ISingletonDesignContext {
   hidden: boolean;
   setContent: (c: Content | undefined) => void;
   editorState: EditorState;


### PR DESCRIPTION
Se habilitan las pruebas de campaña que estaban comentadas por el error generado en el uso de portal para el _Header_ y _Footer_

[DE-583](https://makingsense.atlassian.net/browse/DE-583)