### PR TITLE
Css small change that affects menu-mfe layout

### DIFF
--- a/src/components/Main.css
+++ b/src/components/Main.css
@@ -4,7 +4,7 @@
   display: grid;
   min-height: 100vh;
   grid-template-columns: 1fr;
-  grid-template-rows: 70px 1fr 70px;
+  grid-template-rows: auto 1fr 70px;
 }
 
 #root-header {
@@ -14,10 +14,6 @@
   z-index: 10;
   box-shadow: 0 3px 10px 0 #ddd;
   border-bottom: 1px solid #e5e5e5;
-}
-
-nav {
-  padding: 24px;
 }
 
 #root-footer {


### PR DESCRIPTION
Related JIRA: [DE-678](https://makingsense.atlassian.net/browse/DE-678)

- Nav element extra padding removed
- Set grid template first row to auto, to prevent overlapping when hello bar is present

Before
![editor-pr](https://user-images.githubusercontent.com/94080926/175529979-0953b4ad-36c5-4698-abbc-460a68f7b8eb.png)

After
![editor-pr-after](https://user-images.githubusercontent.com/94080926/175530028-f52acff5-5dfd-4987-9bd4-ab9300b52643.png)

