### PR TITLE
WIP [DE-721] Mostrar spinner cuando se cargan los user field's

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -9,6 +9,7 @@ import { useAppServices } from "./AppServicesContext";
 import { useAppSessionState } from "./AppSessionStateContext";
 import { EditorState } from "./SingletonEditor";
 import { useIntl } from "react-intl";
+import { LoadingScreen } from "./LoadingScreen";
 
 interface ExtendedUnlayerOptions extends UnlayerOptions {
   features: ExtendedFeatures;
@@ -66,11 +67,7 @@ export const Editor = ({
   }
 
   if (userFieldsQuery.isLoading) {
-    return (
-      <div style={containerStyle} {...otherProps}>
-        <p>Loading user's fields...</p>
-      </div>
-    );
+    return <LoadingScreen />;
   }
 
   if (!userFieldsQuery.isSuccess) {


### PR DESCRIPTION
**_Antes_** al cargar el editor de Unlayer se mostraba un texto.

https://user-images.githubusercontent.com/6733401/183470849-cd7a4b72-e29e-493f-b3c6-e111509cf3e5.mp4



**_Ahora_** se muestra un spinner mientras se esta realizando esta carga.

https://user-images.githubusercontent.com/6733401/183470706-7bded2bd-a094-49cc-a60d-e537d62275f8.mp4




