### PR TITLE
[DE-688] Mostrar nombre de campaña en el editor de Unlayer

### DIFF
--- a/src/abstractions/domain/content.ts
+++ b/src/abstractions/domain/content.ts
@@ -1,10 +1,16 @@
 import { Design } from "react-email-editor";
 
 export type Content =
-  | { htmlContent: string; previewImage: string; type: "html" }
+  | {
+      htmlContent: string;
+      previewImage: string;
+      campaignName: string;
+      type: "html";
+    }
   | {
       htmlContent: string;
       design: Design;
       previewImage: string;
+      campaignName: string;
       type: "unlayer";
     };

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -8,7 +8,6 @@ import {
 import { Footer } from "./Footer";
 import { Header } from "./Header";
 import { EditorBottomBar } from "./EditorBottomBar";
-import { useIntl } from "react-intl";
 import { useAppServices } from "./AppServicesContext";
 import { Content } from "../abstractions/domain/content";
 import { LoadingScreen } from "./LoadingScreen";
@@ -28,7 +27,6 @@ export const Campaign = () => {
   const [searchParams] = useSearchParams();
   const campaignContentQuery = useGetCampaignContent(idCampaign);
   const campaignContentMutation = useUpdateCampaignContent();
-  const intl = useIntl();
 
   const { save } = useSingletonEditor(
     {
@@ -73,10 +71,11 @@ export const Campaign = () => {
             <EditorTopBar
               data-testid={editorTopBarTestId}
               onSave={save}
-              title={intl.formatMessage(
-                { id: "campaign_title" },
-                { idCampaign }
-              )}
+              title={
+                campaignContentQuery.data?.campaignName
+                  ? campaignContentQuery.data.campaignName
+                  : ""
+              }
             />
           </Header>
           <Footer>

--- a/src/components/SingletonEditor.test.tsx
+++ b/src/components/SingletonEditor.test.tsx
@@ -88,6 +88,7 @@ const generateNewContent: () => Content = () => ({
     },
   },
   previewImage: "",
+  campaignName: "campaign-name-test",
 });
 
 describe(`${SingletonEditorProvider.name}`, () => {

--- a/src/components/i18n/en.tsx
+++ b/src/components/i18n/en.tsx
@@ -1,6 +1,5 @@
 export const messages_en = {
   campaign: `Campaign`,
-  campaign_title: `Campaign {idCampaign}`,
   campaigns: `Campaigns`,
   continue: `Continue`,
   control_panel: `Control Panel`,

--- a/src/components/i18n/es.tsx
+++ b/src/components/i18n/es.tsx
@@ -1,6 +1,5 @@
 export const messages_es = {
   campaign: `Campaña`,
-  campaign_title: `Campaña {idCampaign}`,
   campaigns: `Campañas`,
   continue: `Continuar`,
   control_panel: `Panel de Control`,

--- a/src/implementations/HtmlEditorApiClientImpl.test.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.test.ts
@@ -81,6 +81,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
         value: {
           design: meta,
           htmlContent,
+          campaignName: "",
           previewImage,
           type: "unlayer",
         },
@@ -155,6 +156,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
         value: {
           htmlContent,
           previewImage,
+          campaignName: "",
           type: "html",
         },
       });
@@ -264,6 +266,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
         htmlContent,
         design,
         previewImage,
+        campaignName: "campaign-name",
         type: "unlayer",
       };
 
@@ -334,6 +337,7 @@ describe(HtmlEditorApiClientImpl.name, () => {
       const content: Content = {
         htmlContent,
         previewImage,
+        campaignName: "campaign-name",
         type: "html",
       };
 

--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -63,6 +63,7 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
         value: {
           htmlContent: response.data.htmlContent,
           previewImage: response.data.previewImage || "",
+          campaignName: response.data.name || "",
           type: "html",
         },
       };
@@ -77,6 +78,7 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
         design: response.data.meta,
         htmlContent: response.data.htmlContent,
         previewImage: response.data.previewImage || "",
+        campaignName: response.data.campaignName || "",
         type: "unlayer",
       },
     };

--- a/src/implementations/dummies/html-editor-api-client.tsx
+++ b/src/implementations/dummies/html-editor-api-client.tsx
@@ -50,6 +50,7 @@ function createUnlayerContent(campaignId: string): Content {
     design: design,
     htmlContent: "<html></html>",
     previewImage: "",
+    campaignName: "Unlayer demo",
     type: "unlayer",
   };
 }
@@ -59,6 +60,7 @@ function createHtmlContent(campaignId: string): Content {
   return {
     htmlContent: `<html><body><div>${text}</div></body></html>`,
     previewImage: "",
+    campaignName: "",
     type: "html",
   };
 }


### PR DESCRIPTION
Ahora se muestra el nombre de la campaña en las campañas de tipo Unlayer

Related to:
* [PR-166](https://github.com/FromDoppler/doppler-html-editor-api/pull/166)
* [DE-688](https://makingsense.atlassian.net/browse/DE-688)
