### PR TITLE
[DE-896] Added button back and next in the template editor

### DIFF
--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -5,6 +5,9 @@ import { useGetTemplate, useUpdateTemplate } from "../queries/template-queries";
 import { Header } from "./Header";
 import { LoadingScreen } from "./LoadingScreen";
 import { Content } from "../abstractions/domain/content";
+import { Footer } from "./Footer";
+import { EditorBottomBar } from "./EditorBottomBar";
+import { useAppServices } from "./AppServicesContext";
 
 export const errorMessageTestId = "error-message";
 export const editorTopBarTestId = "editor-top-bar-message";
@@ -13,6 +16,10 @@ export const Template = () => {
   const { idTemplate } = useParams() as Readonly<{
     idTemplate: string;
   }>;
+
+  const {
+    appConfiguration: { dopplerLegacyBaseUrl },
+  } = useAppServices();
 
   const templateQuery = useGetTemplate(idTemplate);
   const templateMutation = useUpdateTemplate();
@@ -64,6 +71,12 @@ export const Template = () => {
               }
             />
           </Header>
+          <Footer>
+            <EditorBottomBar
+              nextUrl={`${dopplerLegacyBaseUrl}/Templates/Main`}
+              exitUrl={`${dopplerLegacyBaseUrl}/Templates/Main`}
+            ></EditorBottomBar>
+          </Footer>
         </>
       )}
     </>


### PR DESCRIPTION
The footer buttons in template editor have the same design and behavior that in campaign editor, the only difference is that both button redirect to **/Template/Main**

https://user-images.githubusercontent.com/6733401/204587905-6744d7e9-5b23-4dd7-a670-0de27610dfb1.mp4

