### PR TITLE
chore: add configuration for more Doppler's URLs

### DIFF
--- a/src/abstractions/configuration.ts
+++ b/src/abstractions/configuration.ts
@@ -19,4 +19,7 @@ export type dopplerExternalUrls = {
   readonly campaigns: string;
   readonly lists: string;
   readonly controlPanel: string;
+  readonly automation: string;
+  readonly templates: string;
+  readonly integrations: string;
 };

--- a/src/components/EditorTopBar.test.tsx
+++ b/src/components/EditorTopBar.test.tsx
@@ -10,6 +10,9 @@ const appConfiguration = {
     campaigns: "campaignUrl",
     lists: "listsUrl",
     controlPanel: "controlPanelUrl",
+    automation: "automationUrl",
+    templates: "templatesUrl",
+    integrations: "integrationsUrl",
   },
 };
 

--- a/src/components/Template.test.tsx
+++ b/src/components/Template.test.tsx
@@ -28,6 +28,9 @@ const baseAppServices = {
       campaigns: "https://dopplerexternalurls.campaigns/",
       lists: "https://dopplerexternalurls.lists/",
       controlPanel: "https://dopplerexternalurls.controlpanel/",
+      automation: "https://dopplerexternalurls.automation/",
+      templates: "https://dopplerexternalurls.templates/",
+      integrations: "https://dopplerexternalurls.integrations/",
     },
   },
 } as AppServices;

--- a/src/default-configuration.ts
+++ b/src/default-configuration.ts
@@ -21,5 +21,9 @@ export const defaultAppConfiguration: AppConfiguration = {
     campaigns: "https://app2.fromdoppler.com/Campaigns/Draft",
     lists: "https://app2.fromdoppler.com/Lists/SubscribersList",
     controlPanel: "https://app2.fromdoppler.com/ControlPanel/ControlPanel",
+    automation:
+      "https://app2.fromdoppler.com/Automation/Automation/AutomationApp",
+    templates: "https://app2.fromdoppler.com/Templates/Main",
+    integrations: "https://app.fromdoppler.com/integrations",
   },
 };


### PR DESCRIPTION
I will use Templates URL to redirect back from Unlayer Editor in some circumstances.

Related to https://github.com/MakingSense/doppler-swarm/pull/716