### PR TITLE
[DE-902] Base url asset for unlayer editor

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -128,7 +128,8 @@ export const Editor = ({
     },
     customJS: [
       `window["unlayer-extensions-configuration"] = {
-        locale: "${intl.locale}"
+        locale: "${intl.locale}",
+        baseAssetsUrl : "https://app2.dopplerfiles.com/MSEditor/images"
       };`,
       loaderUrl,
       `(new AssetServices()).load('${unlayerEditorManifestUrl}', []);`,


### PR DESCRIPTION
Adding the URL base for Unlayer resources [DE-902](https://makingsense.atlassian.net/browse/DE-902)

[DE-902]: https://makingsense.atlassian.net/browse/DE-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ