### PR TITLE
refactor: use declarative mode to redirect on error creating template from template

### DIFF
--- a/src/components/CreateTemplateFromTemplate.tsx
+++ b/src/components/CreateTemplateFromTemplate.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { Navigate, useLocation, useParams } from "react-router-dom";
+import { NavigateToExternalUrl } from "./NavigateToExternalUrl";
 import { useCreateTemplateFromTemplate } from "../queries/template-queries";
 import { useAppServices } from "./AppServicesContext";
 import { LoadingScreen } from "./LoadingScreen";
@@ -33,7 +34,7 @@ export const CreateTemplateFromTemplate = () => {
       "Error creating template from template",
       error || data
     );
-    window.location.href = templatesUrl;
+    return <NavigateToExternalUrl to={templatesUrl} />;
   }
 
   return <LoadingScreen />;


### PR DESCRIPTION
I am not sure if it is a good change, and I did not update the tests yet.

In my opinion, it is good because I am centralizing all redirect actions in only a declarative way, wrapping the usage of `window` global object.

What do you think?