### PR TITLE
DE-932 - Accept continuation URL parameters

### DIFF
--- a/src/abstractions/configuration.ts
+++ b/src/abstractions/configuration.ts
@@ -12,6 +12,7 @@ export type AppConfiguration = {
   readonly dopplerRestApiBaseUrl: string;
   readonly useDummies: boolean;
   readonly dopplerExternalUrls: dopplerExternalUrls;
+  readonly dopplerUrlRegex: RegExp;
 };
 
 export type dopplerExternalUrls = {

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -1,4 +1,4 @@
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useSingletonEditor } from "./SingletonEditor";
 import { EditorTopBar } from "./EditorTopBar";
 import {
@@ -8,9 +8,9 @@ import {
 import { Footer } from "./Footer";
 import { Header } from "./Header";
 import { EditorBottomBar } from "./EditorBottomBar";
-import { useAppServices } from "./AppServicesContext";
 import { Content } from "../abstractions/domain/content";
 import { LoadingScreen } from "./LoadingScreen";
+import { useCampaignContinuationUrls } from "./continuation-urls";
 
 export const errorMessageTestId = "error-message";
 export const editorTopBarTestId = "editor-top-bar-message";
@@ -20,11 +20,6 @@ export const Campaign = () => {
     idCampaign: string;
   }>;
 
-  const {
-    appConfiguration: { dopplerLegacyBaseUrl, dopplerExternalUrls },
-  } = useAppServices();
-
-  const [searchParams] = useSearchParams();
   const campaignContentQuery = useGetCampaignContent(idCampaign);
   const campaignContentMutation = useUpdateCampaignContent();
 
@@ -38,6 +33,8 @@ export const Campaign = () => {
     [campaignContentQuery.data, campaignContentMutation.mutate, idCampaign]
   );
 
+  const continuationUrls = useCampaignContinuationUrls(idCampaign);
+
   if (campaignContentQuery.error) {
     return (
       <div data-testid={errorMessageTestId}>
@@ -46,20 +43,6 @@ export const Campaign = () => {
       </div>
     );
   }
-
-  const redirectedFromSummary =
-    searchParams.get("redirectedFromSummary")?.toUpperCase() === "TRUE";
-
-  const idABTest = searchParams.get("idABTest");
-  const fixedIdCampaign = idABTest ? idABTest : idCampaign;
-  const testABIndexSegment = idABTest ? "TestAB" : "Index";
-
-  const nextUrl = redirectedFromSummary
-    ? `${dopplerLegacyBaseUrl}/Campaigns/Summary/${testABIndexSegment}?IdCampaign=${fixedIdCampaign}`
-    : `${dopplerLegacyBaseUrl}/Campaigns/Recipients/${testABIndexSegment}?IdCampaign=${fixedIdCampaign}` +
-      `&RedirectedFromSummary=False&RedirectedFromTemplateList=False`;
-
-  const exitUrl = dopplerExternalUrls.campaigns;
 
   return (
     <>
@@ -79,10 +62,7 @@ export const Campaign = () => {
             />
           </Header>
           <Footer>
-            <EditorBottomBar
-              nextUrl={nextUrl}
-              exitUrl={exitUrl}
-            ></EditorBottomBar>
+            <EditorBottomBar {...continuationUrls}></EditorBottomBar>
           </Footer>
         </>
       )}

--- a/src/components/CreateTemplateFromTemplate.test.tsx
+++ b/src/components/CreateTemplateFromTemplate.test.tsx
@@ -111,7 +111,8 @@ describe(CreateTemplateFromTemplate.name, () => {
     // Arrange
     const idTemplate = "456";
     const initialPath = `/templates/create-from-template/${idTemplate}`;
-    const initialSearch = "?abc=cde&x=true";
+    const initialSearch =
+      "?abc=cde&exit=https%3A%2F%2Fexternalurl.fromdoppler.net%2Fexit";
     const initialUrl = `${initialPath}${initialSearch}`;
 
     const {

--- a/src/components/CreateTemplateFromTemplate.test.tsx
+++ b/src/components/CreateTemplateFromTemplate.test.tsx
@@ -6,6 +6,7 @@ import { AppServicesProvider } from "./AppServicesContext";
 import { AppServices } from "../abstractions";
 import { InitialEntry } from "history";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { defaultAppConfiguration } from "../default-configuration";
 
 function createTestContext() {
   const templatesUrl = "https://dopplerexternalurls.templates/";
@@ -44,6 +45,7 @@ function createTestContext() {
   const appServices = {
     htmlEditorApiClient: htmlEditorApiClientDouble,
     appConfiguration: {
+      ...defaultAppConfiguration,
       dopplerExternalUrls: {
         templates: templatesUrl,
       },

--- a/src/components/CreateTemplateFromTemplate.tsx
+++ b/src/components/CreateTemplateFromTemplate.tsx
@@ -4,6 +4,7 @@ import { NavigateToExternalUrl } from "./NavigateToExternalUrl";
 import { useCreateTemplateFromTemplate } from "../queries/template-queries";
 import { useAppServices } from "./AppServicesContext";
 import { LoadingScreen } from "./LoadingScreen";
+import { useTemplatesContinuationUrls } from "./continuation-urls";
 
 export const CreateTemplateFromTemplate = () => {
   const { idTemplate } = useParams() as Readonly<{
@@ -11,18 +12,15 @@ export const CreateTemplateFromTemplate = () => {
   }>;
 
   const { search } = useLocation();
-  const {
-    window,
-    appConfiguration: {
-      dopplerExternalUrls: { templates: templatesUrl },
-    },
-  } = useAppServices();
+  const { window } = useAppServices();
   const { mutate, isIdle, isLoading, isSuccess, data, error } =
     useCreateTemplateFromTemplate();
 
   useEffect(() => {
     mutate({ baseTemplateId: idTemplate });
   }, [mutate, idTemplate]);
+
+  const { exitUrl } = useTemplatesContinuationUrls();
 
   if (isSuccess && data?.success && data?.value?.newTemplateId) {
     const templateUrl = `/templates/${data?.value?.newTemplateId}${search}`;
@@ -34,7 +32,7 @@ export const CreateTemplateFromTemplate = () => {
       "Error creating template from template",
       error || data
     );
-    return <NavigateToExternalUrl to={templatesUrl} />;
+    return <NavigateToExternalUrl to={exitUrl} />;
   }
 
   return <LoadingScreen />;

--- a/src/components/SetCampaignContentFromTemplate.test.tsx
+++ b/src/components/SetCampaignContentFromTemplate.test.tsx
@@ -90,7 +90,8 @@ describe(SetCampaignContentFromTemplate.name, () => {
     const idCampaign = "123";
     const idTemplate = "456";
     const initialPath = `/campaigns/${idCampaign}/set-content-from-template/${idTemplate}`;
-    const initialSearch = "?abc=cde&x=true";
+    const initialSearch =
+      "?abc=cde&exit=https%3A%2F%2Fexternalurl.fromdoppler.net%2Fexit";
     const initialUrl = `${initialPath}${initialSearch}`;
     const expectedPath = `/campaigns/${idCampaign}`;
 

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -7,7 +7,7 @@ import { LoadingScreen } from "./LoadingScreen";
 import { Content } from "../abstractions/domain/content";
 import { Footer } from "./Footer";
 import { EditorBottomBar } from "./EditorBottomBar";
-import { useAppServices } from "./AppServicesContext";
+import { useTemplatesContinuationUrls } from "./continuation-urls";
 
 export const errorMessageTestId = "error-message";
 export const editorTopBarTestId = "editor-top-bar-message";
@@ -16,10 +16,7 @@ export const Template = () => {
   const { idTemplate } = useParams() as Readonly<{
     idTemplate: string;
   }>;
-
-  const {
-    appConfiguration: { dopplerLegacyBaseUrl },
-  } = useAppServices();
+  const continuationUrls = useTemplatesContinuationUrls();
 
   const templateQuery = useGetTemplate(idTemplate);
   const templateMutation = useUpdateTemplate();
@@ -72,10 +69,7 @@ export const Template = () => {
             />
           </Header>
           <Footer>
-            <EditorBottomBar
-              nextUrl={`${dopplerLegacyBaseUrl}/Templates/Main`}
-              exitUrl={`${dopplerLegacyBaseUrl}/Templates/Main`}
-            ></EditorBottomBar>
+            <EditorBottomBar {...continuationUrls}></EditorBottomBar>
           </Footer>
         </>
       )}

--- a/src/components/continuation-urls.test.tsx
+++ b/src/components/continuation-urls.test.tsx
@@ -67,6 +67,37 @@ describe(useTemplatesContinuationUrls.name, () => {
       expectedExitUrl:
         "https://app.legacyBaseUrl.fromdoppler.net/Templates/Main",
     },
+    {
+      scenario: "querystring contains next",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor" +
+        "?next=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FNext%3F123%26abc%3D1",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Next?123&abc=1",
+      expectedExitUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Templates/Main",
+    },
+    {
+      scenario: "querystring contains exit",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor" +
+        "?exit=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FExit%3F123%26abc%3D1",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Templates/Main",
+      expectedExitUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
+    },
+    {
+      scenario: "querystring contains exit and next",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor" +
+        "?next=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FNext%3F123%26abc%3D1" +
+        "&exit=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FExit%3F123%26abc%3D1",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Next?123&abc=1",
+      expectedExitUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
+    },
   ])(
     "should return continuation URLs based on querystring parameters when $scenario",
     ({ currentRouterEntry, expectedNextUrl, expectedExitUrl }) => {
@@ -121,6 +152,62 @@ describe(useCampaignContinuationUrls.name, () => {
         "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Recipients/TestAB" +
         "?IdCampaign=456&RedirectedFromSummary=False&RedirectedFromTemplateList=False",
       expectedExitUrl: campaignsExternalUrl,
+    },
+    {
+      scenario: "querystring contains next",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor" +
+        "?next=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FNext%3F123%26abc%3D1",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Next?123&abc=1",
+      expectedExitUrl: campaignsExternalUrl,
+    },
+    {
+      scenario: "querystring contains exit",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor" +
+        "?exit=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FExit%3F123%26abc%3D1",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Recipients/Index" +
+        "?IdCampaign=123&RedirectedFromSummary=False&RedirectedFromTemplateList=False",
+      expectedExitUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
+    },
+    {
+      scenario: "querystring contains exit and idABTest is set",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor" +
+        "?idABTest=456&exit=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FExit%3F123%26abc%3D1",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Recipients/TestAB" +
+        "?IdCampaign=456&RedirectedFromSummary=False&RedirectedFromTemplateList=False",
+      expectedExitUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
+    },
+    {
+      scenario: "querystring contains exit and next",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor" +
+        "?next=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FNext%3F123%26abc%3D1" +
+        "&exit=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FExit%3F123%26abc%3D1",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Next?123&abc=1",
+      expectedExitUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
+    },
+    {
+      scenario:
+        "querystring contains exit and next and also TestAB and redirectedFromSummary (exit and next wins)",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor" +
+        "?redirectedFromSummary=true" +
+        "&idABTest=456" +
+        "&next=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FNext%3F123%26abc%3D1" +
+        "&exit=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FExit%3F123%26abc%3D1",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Next?123&abc=1",
+      expectedExitUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
     },
   ])(
     "should return continuation URLs based on querystring parameters when $scenario",

--- a/src/components/continuation-urls.test.tsx
+++ b/src/components/continuation-urls.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { AppServices } from "../abstractions";
+import { defaultAppConfiguration } from "../default-configuration";
 import { AppServicesProvider } from "./AppServicesContext";
 import {
   useCampaignContinuationUrls,
@@ -34,8 +35,12 @@ function buildTestScenario({
           appServices={
             {
               appConfiguration: {
+                ...defaultAppConfiguration,
                 dopplerLegacyBaseUrl,
-                dopplerExternalUrls: { campaigns: campaignsExternalUrl },
+                dopplerExternalUrls: {
+                  ...defaultAppConfiguration.dopplerExternalUrls,
+                  campaigns: campaignsExternalUrl,
+                },
               },
             } as AppServices
           }

--- a/src/components/continuation-urls.test.tsx
+++ b/src/components/continuation-urls.test.tsx
@@ -88,7 +88,7 @@ describe(useTemplatesContinuationUrls.name, () => {
         "https://webapp.formdoppler.net/editor" +
         "?exit=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FExit%3F123%26abc%3D1",
       expectedNextUrl:
-        "https://app.legacyBaseUrl.fromdoppler.net/Templates/Main",
+        "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
       expectedExitUrl:
         "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
     },
@@ -185,8 +185,7 @@ describe(useCampaignContinuationUrls.name, () => {
         "https://webapp.formdoppler.net/editor" +
         "?exit=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FExit%3F123%26abc%3D1",
       expectedNextUrl:
-        "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Recipients/Index" +
-        "?IdCampaign=123&RedirectedFromSummary=False&RedirectedFromTemplateList=False",
+        "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
       expectedExitUrl:
         "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
     },
@@ -196,8 +195,7 @@ describe(useCampaignContinuationUrls.name, () => {
         "https://webapp.formdoppler.net/editor" +
         "?idABTest=456&exit=https%3A%2F%2Fapp.legacyBaseUrl.fromdoppler.net%2FExit%3F123%26abc%3D1",
       expectedNextUrl:
-        "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Recipients/TestAB" +
-        "?IdCampaign=456&RedirectedFromSummary=False&RedirectedFromTemplateList=False",
+        "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
       expectedExitUrl:
         "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
     },

--- a/src/components/continuation-urls.test.tsx
+++ b/src/components/continuation-urls.test.tsx
@@ -1,0 +1,144 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AppServices } from "../abstractions";
+import { AppServicesProvider } from "./AppServicesContext";
+import {
+  useCampaignContinuationUrls,
+  useTemplatesContinuationUrls,
+} from "./continuation-urls";
+
+type ContinuationUrlsResult = { nextUrl?: string; exitUrl?: string };
+
+function buildTestScenario({
+  currentRouterEntry,
+  dopplerLegacyBaseUrl,
+  campaignsExternalUrl,
+  useHookUnderTesting,
+}: {
+  currentRouterEntry: string;
+  dopplerLegacyBaseUrl: string;
+  campaignsExternalUrl: string;
+  useHookUnderTesting: () => ContinuationUrlsResult;
+}) {
+  let result: ContinuationUrlsResult = {};
+
+  const TestComponent = () => {
+    result = useHookUnderTesting();
+    return <>TestComponent</>;
+  };
+
+  const renderAndGetContinuationUrls = () => {
+    render(
+      <MemoryRouter initialEntries={[currentRouterEntry]}>
+        <AppServicesProvider
+          appServices={
+            {
+              appConfiguration: {
+                dopplerLegacyBaseUrl,
+                dopplerExternalUrls: { campaigns: campaignsExternalUrl },
+              },
+            } as AppServices
+          }
+        >
+          <TestComponent />
+        </AppServicesProvider>
+      </MemoryRouter>
+    );
+    return result;
+  };
+
+  return {
+    renderAndGetContinuationUrls,
+  };
+}
+
+const dopplerLegacyBaseUrl = "https://app.legacyBaseUrl.fromdoppler.net";
+const idCampaign = "123";
+const campaignsExternalUrl =
+  "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Draft/";
+
+describe(useTemplatesContinuationUrls.name, () => {
+  it.each([
+    {
+      scenario: "querystring is empty",
+      currentRouterEntry: "https://webapp.formdoppler.net/editor",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Templates/Main",
+      expectedExitUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Templates/Main",
+    },
+  ])(
+    "should return continuation URLs based on querystring parameters when $scenario",
+    ({ currentRouterEntry, expectedNextUrl, expectedExitUrl }) => {
+      // Arrange
+      const { renderAndGetContinuationUrls } = buildTestScenario({
+        currentRouterEntry,
+        dopplerLegacyBaseUrl,
+        campaignsExternalUrl,
+        useHookUnderTesting: useTemplatesContinuationUrls,
+      });
+
+      // Act
+      const { nextUrl, exitUrl } = renderAndGetContinuationUrls();
+
+      // Assert
+      expect(nextUrl).toBe(expectedNextUrl);
+      expect(exitUrl).toBe(expectedExitUrl);
+    }
+  );
+});
+
+describe(useCampaignContinuationUrls.name, () => {
+  it.each([
+    {
+      scenario: "querystring is empty",
+      currentRouterEntry: "https://webapp.formdoppler.net/editor",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Recipients/Index" +
+        "?IdCampaign=123&RedirectedFromSummary=False&RedirectedFromTemplateList=False",
+      expectedExitUrl: campaignsExternalUrl,
+    },
+    {
+      scenario: "redirectedFromSummary is true",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor?redirectedFromSummary=true",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Summary/Index?IdCampaign=123",
+      expectedExitUrl: campaignsExternalUrl,
+    },
+    {
+      scenario: "redirectedFromSummary is true and idABTest is set",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor?redirectedFromSummary=true&idABTest=456",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Summary/TestAB?IdCampaign=456",
+      expectedExitUrl: campaignsExternalUrl,
+    },
+    {
+      scenario: "idABTest is set",
+      currentRouterEntry: "https://webapp.formdoppler.net/editor?idABTest=456",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Recipients/TestAB" +
+        "?IdCampaign=456&RedirectedFromSummary=False&RedirectedFromTemplateList=False",
+      expectedExitUrl: campaignsExternalUrl,
+    },
+  ])(
+    "should return continuation URLs based on querystring parameters when $scenario",
+    ({ currentRouterEntry, expectedNextUrl, expectedExitUrl }) => {
+      // Arrange
+      const { renderAndGetContinuationUrls } = buildTestScenario({
+        currentRouterEntry,
+        dopplerLegacyBaseUrl,
+        campaignsExternalUrl,
+        useHookUnderTesting: () => useCampaignContinuationUrls(idCampaign),
+      });
+
+      // Act
+      const { nextUrl, exitUrl } = renderAndGetContinuationUrls();
+
+      // Assert
+      expect(nextUrl).toBe(expectedNextUrl);
+      expect(exitUrl).toBe(expectedExitUrl);
+    }
+  );
+});

--- a/src/components/continuation-urls.test.tsx
+++ b/src/components/continuation-urls.test.tsx
@@ -103,6 +103,18 @@ describe(useTemplatesContinuationUrls.name, () => {
       expectedExitUrl:
         "https://app.legacyBaseUrl.fromdoppler.net/Exit?123&abc=1",
     },
+    {
+      scenario:
+        "querystring contains exit and next of invalid domains (should be ignored)",
+      currentRouterEntry:
+        "https://webapp.formdoppler.net/editor" +
+        "?next=https%3A%2F%2Fapp.anotherdomain.net%2FNext%3F123%26abc%3D1" +
+        "&exit=https%3A%2F%2Fapp.fromdoppler.org%2FExit%3F123%26abc%3D1",
+      expectedNextUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Templates/Main",
+      expectedExitUrl:
+        "https://app.legacyBaseUrl.fromdoppler.net/Templates/Main",
+    },
   ])(
     "should return continuation URLs based on querystring parameters when $scenario",
     ({ currentRouterEntry, expectedNextUrl, expectedExitUrl }) => {

--- a/src/components/continuation-urls.test.tsx
+++ b/src/components/continuation-urls.test.tsx
@@ -13,11 +13,13 @@ type ContinuationUrlsResult = { nextUrl?: string; exitUrl?: string };
 function buildTestScenario({
   currentRouterEntry,
   dopplerLegacyBaseUrl,
+  templatesExternalUrl,
   campaignsExternalUrl,
   useHookUnderTesting,
 }: {
   currentRouterEntry: string;
   dopplerLegacyBaseUrl: string;
+  templatesExternalUrl: string;
   campaignsExternalUrl: string;
   useHookUnderTesting: () => ContinuationUrlsResult;
 }) {
@@ -40,6 +42,7 @@ function buildTestScenario({
                 dopplerExternalUrls: {
                   ...defaultAppConfiguration.dopplerExternalUrls,
                   campaigns: campaignsExternalUrl,
+                  templates: templatesExternalUrl,
                 },
               },
             } as AppServices
@@ -58,6 +61,8 @@ function buildTestScenario({
 }
 
 const dopplerLegacyBaseUrl = "https://app.legacyBaseUrl.fromdoppler.net";
+const templatesExternalUrl =
+  "https://app.legacyBaseUrl.fromdoppler.net/Templates/Main";
 const idCampaign = "123";
 const campaignsExternalUrl =
   "https://app.legacyBaseUrl.fromdoppler.net/Campaigns/Draft/";
@@ -122,6 +127,7 @@ describe(useTemplatesContinuationUrls.name, () => {
       const { renderAndGetContinuationUrls } = buildTestScenario({
         currentRouterEntry,
         dopplerLegacyBaseUrl,
+        templatesExternalUrl,
         campaignsExternalUrl,
         useHookUnderTesting: useTemplatesContinuationUrls,
       });
@@ -231,6 +237,7 @@ describe(useCampaignContinuationUrls.name, () => {
       const { renderAndGetContinuationUrls } = buildTestScenario({
         currentRouterEntry,
         dopplerLegacyBaseUrl,
+        templatesExternalUrl,
         campaignsExternalUrl,
         useHookUnderTesting: () => useCampaignContinuationUrls(idCampaign),
       });

--- a/src/components/continuation-urls.ts
+++ b/src/components/continuation-urls.ts
@@ -19,6 +19,9 @@ export function useCampaignContinuationUrls(idCampaign: string) {
 }
 
 function useNextAndExitParametersContinuationUrls() {
+  const {
+    appConfiguration: { dopplerUrlRegex },
+  } = useAppServices();
   const [searchParams] = useSearchParams();
 
   const result: { nextUrl?: string; exitUrl?: string } = {};
@@ -26,13 +29,11 @@ function useNextAndExitParametersContinuationUrls() {
   var nextUrl = searchParams.get("next");
   var exitUrl = searchParams.get("exit");
 
-  // TODO: validate next and exit with a domain whitelist
-
-  if (nextUrl) {
+  if (nextUrl && dopplerUrlRegex.test(nextUrl)) {
     result.nextUrl = nextUrl;
   }
 
-  if (exitUrl) {
+  if (exitUrl && dopplerUrlRegex.test(exitUrl)) {
     result.exitUrl = exitUrl;
   }
 

--- a/src/components/continuation-urls.ts
+++ b/src/components/continuation-urls.ts
@@ -76,10 +76,10 @@ function useDefaultCampaignContinuationUrls() {
 
 function useDefaultTemplateContinuationUrls() {
   const {
-    appConfiguration: { dopplerLegacyBaseUrl },
+    appConfiguration: {
+      dopplerExternalUrls: { templates: templatesUrl },
+    },
   } = useAppServices();
-
-  const templatesUrl = `${dopplerLegacyBaseUrl}/Templates/Main`;
 
   return { nextUrl: templatesUrl, exitUrl: templatesUrl };
 }

--- a/src/components/continuation-urls.ts
+++ b/src/components/continuation-urls.ts
@@ -1,0 +1,57 @@
+import { useSearchParams } from "react-router-dom";
+import { useAppServices } from "./AppServicesContext";
+
+export function useTemplatesContinuationUrls() {
+  const defaultUrls = useDefaultTemplateContinuationUrls();
+  return { ...defaultUrls };
+}
+
+export function useCampaignContinuationUrls(idCampaign: string) {
+  const defaultUrls = useDefaultCampaignContinuationUrls();
+  const legacyResolvedUrls = useLegacyCampaignContinuationUrls(idCampaign);
+  return { ...defaultUrls, ...legacyResolvedUrls };
+}
+
+/** Obsolete: we are tending to use exit and next querystring parameters, see DE-932 */
+function useLegacyCampaignContinuationUrls(idCampaign: string) {
+  const [searchParams] = useSearchParams();
+
+  const {
+    appConfiguration: { dopplerLegacyBaseUrl },
+  } = useAppServices();
+
+  const redirectedFromSummary =
+    searchParams.get("redirectedFromSummary")?.toUpperCase() === "TRUE";
+
+  const idABTest = searchParams.get("idABTest");
+  const fixedIdCampaign = idABTest ? idABTest : idCampaign;
+  const testABIndexSegment = idABTest ? "TestAB" : "Index";
+
+  const nextUrl = redirectedFromSummary
+    ? `${dopplerLegacyBaseUrl}/Campaigns/Summary/${testABIndexSegment}?IdCampaign=${fixedIdCampaign}`
+    : `${dopplerLegacyBaseUrl}/Campaigns/Recipients/${testABIndexSegment}?IdCampaign=${fixedIdCampaign}` +
+      `&RedirectedFromSummary=False&RedirectedFromTemplateList=False`;
+
+  return { nextUrl };
+}
+
+function useDefaultCampaignContinuationUrls() {
+  const {
+    appConfiguration: { dopplerExternalUrls },
+  } = useAppServices();
+
+  return {
+    nextUrl: dopplerExternalUrls.campaigns,
+    exitUrl: dopplerExternalUrls.campaigns,
+  };
+}
+
+function useDefaultTemplateContinuationUrls() {
+  const {
+    appConfiguration: { dopplerLegacyBaseUrl },
+  } = useAppServices();
+
+  const templatesUrl = `${dopplerLegacyBaseUrl}/Templates/Main`;
+
+  return { nextUrl: templatesUrl, exitUrl: templatesUrl };
+}

--- a/src/components/continuation-urls.ts
+++ b/src/components/continuation-urls.ts
@@ -3,13 +3,40 @@ import { useAppServices } from "./AppServicesContext";
 
 export function useTemplatesContinuationUrls() {
   const defaultUrls = useDefaultTemplateContinuationUrls();
-  return { ...defaultUrls };
+  const nextAndExitUrls = useNextAndExitParametersContinuationUrls();
+  return { ...defaultUrls, ...nextAndExitUrls };
 }
 
 export function useCampaignContinuationUrls(idCampaign: string) {
   const defaultUrls = useDefaultCampaignContinuationUrls();
   const legacyResolvedUrls = useLegacyCampaignContinuationUrls(idCampaign);
-  return { ...defaultUrls, ...legacyResolvedUrls };
+  const nextAndExitUrls = useNextAndExitParametersContinuationUrls();
+  return {
+    ...defaultUrls,
+    ...legacyResolvedUrls,
+    ...nextAndExitUrls,
+  };
+}
+
+function useNextAndExitParametersContinuationUrls() {
+  const [searchParams] = useSearchParams();
+
+  const result: { nextUrl?: string; exitUrl?: string } = {};
+
+  var nextUrl = searchParams.get("next");
+  var exitUrl = searchParams.get("exit");
+
+  // TODO: validate next and exit with a domain whitelist
+
+  if (nextUrl) {
+    result.nextUrl = nextUrl;
+  }
+
+  if (exitUrl) {
+    result.exitUrl = exitUrl;
+  }
+
+  return result;
 }
 
 /** Obsolete: we are tending to use exit and next querystring parameters, see DE-932 */

--- a/src/components/continuation-urls.ts
+++ b/src/components/continuation-urls.ts
@@ -26,8 +26,8 @@ function useNextAndExitParametersContinuationUrls() {
 
   const result: { nextUrl?: string; exitUrl?: string } = {};
 
-  var nextUrl = searchParams.get("next");
   var exitUrl = searchParams.get("exit");
+  var nextUrl = searchParams.get("next") || exitUrl;
 
   if (nextUrl && dopplerUrlRegex.test(nextUrl)) {
     result.nextUrl = nextUrl;

--- a/src/default-configuration.ts
+++ b/src/default-configuration.ts
@@ -26,4 +26,5 @@ export const defaultAppConfiguration: AppConfiguration = {
     templates: "https://app2.fromdoppler.com/Templates/Main",
     integrations: "https://app.fromdoppler.com/integrations",
   },
+  dopplerUrlRegex: /^https:\/\/(?:[\w.-]+\.)?fromdoppler\.(?:com|net)(?:\/|$)/,
 };


### PR DESCRIPTION
Hi team!

This change allows us to accept `next` and `exit` query-string parameters, enabling Doppler to decide what to do after editing content.

![image](https://user-images.githubusercontent.com/1157864/212714460-1f4a30d3-f7c4-4071-b88a-39e4caae60d8.png)
