### PR TITLE
[DE-869] Add test for export content as template

### DIFF
--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -395,7 +395,7 @@ describe(Campaign.name, () => {
     renderEditor(<DoubleEditorWithStateLoaded initialEntries={["/000"]} />);
 
     await waitFor(async () => {
-      const exportToTemplate = await screen.findByRole("export_to_template");
+      const exportToTemplate = await screen.findByText("save_template");
       act(() => exportToTemplate.click());
       await waitFor(() => expect(exportToTemplate).toBeDisabled());
     });
@@ -405,7 +405,7 @@ describe(Campaign.name, () => {
     // Act
     renderEditor(<DoubleEditorWithStateLoaded initialEntries={["/000"]} />);
 
-    const exportToTemplate = await screen.findByRole("export_to_template");
+    const exportToTemplate = await screen.findByText("save_template");
     await act(() => exportToTemplate.click());
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
     expect(exportToTemplate).toBeEnabled();

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -66,7 +66,7 @@ const DoubleEditorWithStateLoaded = ({
   initialEntries,
 }: SetEditorAsLoadedProps) => {
   const getCampaignContent = () =>
-    Promise.resolve({ success: true, value: {} });
+    Promise.resolve({ success: true, value: { type: "unlayer" } });
   const updateCampaignContent = jest.fn(() =>
     Promise.resolve({ success: true, value: {} })
   );
@@ -389,4 +389,25 @@ describe(Campaign.name, () => {
       );
     }
   );
+
+  it("export button must be disabled when is exporting as template", async () => {
+    // Act
+    renderEditor(<DoubleEditorWithStateLoaded initialEntries={["/000"]} />);
+
+    await waitFor(async () => {
+      const exportToTemplate = await screen.findByRole("export_to_template");
+      act(() => exportToTemplate.click());
+      await waitFor(() => expect(exportToTemplate).toBeDisabled());
+    });
+  });
+
+  it("export modal must open when click in export as template", async () => {
+    // Act
+    renderEditor(<DoubleEditorWithStateLoaded initialEntries={["/000"]} />);
+
+    const exportToTemplate = await screen.findByRole("export_to_template");
+    await act(() => exportToTemplate.click());
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(exportToTemplate).toBeEnabled();
+  });
 });

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -88,7 +88,6 @@ export const Campaign = () => {
                   <li>
                     <button
                       type="button"
-                      role="export_to_template"
                       onClick={openExportModal}
                       disabled={isExportingAsTemplate}
                       className={`dp-button button-medium primary-green ${

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -88,6 +88,7 @@ export const Campaign = () => {
                   <li>
                     <button
                       type="button"
+                      role="export_to_template"
                       onClick={openExportModal}
                       disabled={isExportingAsTemplate}
                       className={`dp-button button-medium primary-green ${

--- a/src/components/SaveAsTemplateModal.test.tsx
+++ b/src/components/SaveAsTemplateModal.test.tsx
@@ -1,0 +1,78 @@
+import { SaveAsTemplateModal } from "./SaveAsTemplateModal";
+import { UnlayerContent } from "../abstractions/domain/content";
+import { Design } from "react-email-editor";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
+import userEvent from "@testing-library/user-event";
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        cacheTime: 0,
+      },
+    },
+  });
+
+describe(SaveAsTemplateModal.name, () => {
+  it("should be render the modal with default name", async () => {
+    // Arrange
+    const unlayerContent: UnlayerContent = {
+      design: { test: "Demo data" } as unknown as Design,
+      htmlContent: "<html><p></p></html>",
+      previewImage: "",
+      type: "unlayer",
+    };
+    const defaultName = "default-name";
+    // Act
+    render(
+      <QueryClientProvider client={createQueryClient()}>
+        <TestDopplerIntlProvider>
+          <SaveAsTemplateModal
+            close={() => {}}
+            isOpen={true}
+            content={unlayerContent}
+            defaultName={defaultName}
+          />
+        </TestDopplerIntlProvider>
+      </QueryClientProvider>
+    );
+
+    screen.getByRole("dialog");
+    const inputName = await screen.getByLabelText("new_template_label");
+    expect(inputName).toHaveValue(defaultName);
+    await act(() => userEvent.type(inputName, "-with-changes"));
+    expect(inputName).toHaveValue(`${defaultName}-with-changes`);
+  });
+
+  it("should be show the success message when click on accept button", async () => {
+    // Arrange
+    const unlayerContent: UnlayerContent = {
+      design: { test: "Demo data" } as unknown as Design,
+      htmlContent: "<html><p></p></html>",
+      previewImage: "",
+      type: "unlayer",
+    };
+    const defaultName = "default-name";
+    // Act
+    render(
+      <QueryClientProvider client={createQueryClient()}>
+        <TestDopplerIntlProvider>
+          <SaveAsTemplateModal
+            close={() => {}}
+            isOpen={true}
+            content={unlayerContent}
+            defaultName={defaultName}
+          />
+        </TestDopplerIntlProvider>
+      </QueryClientProvider>
+    );
+
+    screen.getByRole("dialog");
+    const submitButton = await screen.getByText("save");
+    act(() => userEvent.click(submitButton));
+    waitFor(() => screen.getByText("new_template_has_been_saved"));
+  });
+});

--- a/src/components/Template.test.tsx
+++ b/src/components/Template.test.tsx
@@ -234,4 +234,36 @@ describe(Template.name, () => {
       });
     });
   });
+
+  it("shouldn't show the export button", async () => {
+    // Arrange
+    const idTemplate = "1234";
+    const getTemplate = jest.fn(() =>
+      Promise.resolve({ success: true, value: { type: "unlayer" } })
+    );
+
+    const htmlEditorApiClient = {
+      getTemplate,
+    } as unknown as HtmlEditorApiClient;
+
+    // Act
+    renderEditor(
+      <QueryClientProvider client={createQueryClient()}>
+        <AppServicesProvider
+          appServices={{ ...baseAppServices, htmlEditorApiClient }}
+        >
+          <TestDopplerIntlProvider>
+            <MemoryRouter initialEntries={[`/${idTemplate}`]}>
+              <Routes>
+                <Route path="/:idTemplate" element={<Template />} />
+              </Routes>
+            </MemoryRouter>
+          </TestDopplerIntlProvider>
+        </AppServicesProvider>
+      </QueryClientProvider>
+    );
+
+    // Assert
+    expect(() => screen.getByRole("export_to_template")).toThrow();
+  });
 });


### PR DESCRIPTION
Added test for open modal behavior and success message.

Related to: [DE-896](https://makingsense.atlassian.net/browse/DE-869)

[DE-896]: https://makingsense.atlassian.net/browse/DE-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ