### PR TITLE
Fix: Request to create template from content

### DIFF
--- a/src/implementations/HtmlEditorApiClientImpl.ts
+++ b/src/implementations/HtmlEditorApiClientImpl.ts
@@ -180,9 +180,15 @@ export class HtmlEditorApiClientImpl implements HtmlEditorApiClient {
   }
 
   async createPrivateTemplate(
-    template: TemplateContent
+    content: TemplateContent
   ): Promise<Result<{ newTemplateId: string }>> {
-    const body = {};
+    const body = {
+      meta: content.design,
+      htmlContent: content.htmlContent,
+      previewImage: content.previewImage,
+      type: "unlayer",
+      templateName: content.templateName,
+    };
     const result = await this.POST(`/templates`, body);
     return {
       success: true,


### PR DESCRIPTION
When export content to template the requests threw an exception because the body was empty, now is sending the correct content data to create template.

https://user-images.githubusercontent.com/6733401/218569498-9ab502c0-14ed-4724-aba9-e57f0d07ce55.mp4

