### PR TITLE
Refactor Campaign Page tests

### DIFF
--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -320,19 +320,21 @@ describe(Campaign.name, () => {
   it.each([
     {
       buttonText: "continue",
+      idCampaign: "idCampaign",
       searchParams: "redirectedFromSummary=true",
       urlExpected: `${dopplerLegacyBaseUrl}/Campaigns/Summary/Index?IdCampaign=idCampaign`,
     },
     {
       buttonText: "continue",
+      idCampaign: "idCampaign",
       searchParams: "redirectedFromSummary=true&idABTest=idABTest",
       urlExpected: `${dopplerLegacyBaseUrl}/Campaigns/Summary/TestAB?IdCampaign=idABTest`,
     },
   ])(
     "should redirect to summary when $searchParams and user click in $buttonText",
-    async ({ buttonText, urlExpected, searchParams }) => {
+    async ({ buttonText, idCampaign, searchParams, urlExpected }) => {
       // Arrange
-      const initialEntries = `/idCampaign?${searchParams}`;
+      const initialEntries = `/${idCampaign}?${searchParams}`;
       renderEditor(
         <DoubleEditorWithStateLoaded initialEntries={[initialEntries]} />
       );
@@ -352,6 +354,7 @@ describe(Campaign.name, () => {
   it.each([
     {
       buttonText: "continue",
+      idCampaign: "idCampaign",
       searchParams: "redirectedFromSummary=false",
       urlExpected:
         `${dopplerLegacyBaseUrl}/Campaigns/Recipients/Index?IdCampaign=idCampaign` +
@@ -359,6 +362,7 @@ describe(Campaign.name, () => {
     },
     {
       buttonText: "continue",
+      idCampaign: "idCampaign",
       searchParams: "redirectedFromSummary=false&idABTest=idABTest",
       urlExpected:
         `${dopplerLegacyBaseUrl}/Campaigns/Recipients/TestAB?IdCampaign=idABTest` +
@@ -366,9 +370,9 @@ describe(Campaign.name, () => {
     },
   ])(
     "no should redirect to summary when $searchParams and user click in $buttonText",
-    async ({ buttonText, urlExpected, searchParams }) => {
+    async ({ buttonText, idCampaign, searchParams, urlExpected }) => {
       // Arrange
-      const initialEntries = [`/idCampaign?${searchParams}`];
+      const initialEntries = [`/${idCampaign}?${searchParams}`];
       renderEditor(
         <DoubleEditorWithStateLoaded initialEntries={initialEntries} />
       );

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -94,8 +94,9 @@ const DoubleEditorWithStateLoaded = ({
 
   const design = { test: "Demo data" } as unknown as Design;
   const htmlContent = "<html><p></p></html>";
+  const exportedImageUrl = "https://test.fromdoppler.net/exportedImageUrl.png";
   const exportHtml = (cb: any) => cb({ design, html: htmlContent });
-  const exportImage = (cb: any) => cb({ url: "" });
+  const exportImage = (cb: any) => cb({ url: exportedImageUrl });
 
   const singletonEditorContext: ISingletonDesignContext = {
     hidden: false,
@@ -252,8 +253,10 @@ describe(Campaign.name, () => {
       const idCampaign = "1234";
       const design = { test: "Demo data" } as unknown as Design;
       const htmlContent = "<html><p></p></html>";
+      const exportedImageUrl =
+        "https://test.fromdoppler.net/exportedImageUrl.png";
       const exportHtml = (cb: any) => cb({ design, html: htmlContent });
-      const exportImage = (cb: any) => cb({ url: "" });
+      const exportImage = (cb: any) => cb({ url: exportedImageUrl });
 
       const getCampaignContent = () =>
         Promise.resolve({ success: true, value: {} });
@@ -311,7 +314,7 @@ describe(Campaign.name, () => {
       expect(updateCampaignContent).toHaveBeenCalledWith(idCampaign, {
         design,
         htmlContent,
-        previewImage: "",
+        previewImage: exportedImageUrl,
         type: "unlayer",
       });
     }

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -92,11 +92,11 @@ const DoubleEditorWithStateLoaded = ({
     updateCampaignContent,
   } as unknown as HtmlEditorApiClient;
 
-  const design = { test: "Demo data" } as unknown as Design;
-  const htmlContent = "<html><p></p></html>";
-  const exportedImageUrl = "https://test.fromdoppler.net/exportedImageUrl.png";
-  const exportHtml = (cb: any) => cb({ design, html: htmlContent });
-  const exportImage = (cb: any) => cb({ url: exportedImageUrl });
+  const editorDesign = { test: "Demo data" } as unknown as Design;
+  const editorHtmlContent = "<html><p></p></html>";
+  const editorExportedImageUrl = "https://test.fromdoppler.net/exportedImageUrl.png";
+  const exportHtml = (cb: any) => cb({ design: editorDesign, html: editorHtmlContent });
+  const exportImage = (cb: any) => cb({ url: editorExportedImageUrl });
 
   const singletonEditorContext: ISingletonDesignContext = {
     hidden: false,
@@ -251,12 +251,11 @@ describe(Campaign.name, () => {
     async ({ buttonText }) => {
       // Arrange
       const idCampaign = "1234";
-      const design = { test: "Demo data" } as unknown as Design;
-      const htmlContent = "<html><p></p></html>";
-      const exportedImageUrl =
-        "https://test.fromdoppler.net/exportedImageUrl.png";
-      const exportHtml = (cb: any) => cb({ design, html: htmlContent });
-      const exportImage = (cb: any) => cb({ url: exportedImageUrl });
+      const editorDesign = { test: "Demo data" } as unknown as Design;
+      const editorHtmlContent = "<html><p></p></html>";
+      const editorExportedImageUrl = "https://test.fromdoppler.net/exportedImageUrl.png";
+      const exportHtml = (cb: any) => cb({ design: editorDesign, html: editorHtmlContent });
+      const exportImage = (cb: any) => cb({ url: editorExportedImageUrl });
 
       const getCampaignContent = () =>
         Promise.resolve({ success: true, value: {} });
@@ -312,9 +311,9 @@ describe(Campaign.name, () => {
 
       // Assert
       expect(updateCampaignContent).toHaveBeenCalledWith(idCampaign, {
-        design,
-        htmlContent,
-        previewImage: exportedImageUrl,
+        design: editorDesign,
+        htmlContent: editorHtmlContent,
+        previewImage: editorExportedImageUrl,
         type: "unlayer",
       });
     }

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -151,7 +151,6 @@ describe(Campaign.name, () => {
       getCampaignContent,
     } as unknown as HtmlEditorApiClient;
 
-    // Act
     renderEditor(
       <QueryClientProvider client={createQueryClient()}>
         <AppServicesProvider
@@ -172,14 +171,10 @@ describe(Campaign.name, () => {
       </QueryClientProvider>
     );
 
-    // Assert
     expect(getCampaignContent).toHaveBeenCalledWith(idCampaign);
-
     screen.getByText("Loading...");
-
     const topBarMustBeNull = screen.queryByTestId(editorTopBarTestId);
     expect(topBarMustBeNull).toBeNull();
-
     const errorMessageEl = screen.queryByTestId(errorMessageTestId);
     expect(errorMessageEl).toBeNull();
 
@@ -211,7 +206,6 @@ describe(Campaign.name, () => {
       getCampaignContent,
     } as unknown as HtmlEditorApiClient;
 
-    // Act
     renderEditor(
       <QueryClientProvider client={createQueryClient()}>
         <AppServicesProvider
@@ -232,12 +226,9 @@ describe(Campaign.name, () => {
       </QueryClientProvider>
     );
 
-    // Assert
     screen.getByText("Loading...");
-
     const errorMessageEl = screen.queryByTestId(errorMessageTestId);
     expect(errorMessageEl).toBeNull();
-
     expect(getCampaignContent).toHaveBeenCalledWith(idCampaign);
 
     // Act
@@ -289,7 +280,6 @@ describe(Campaign.name, () => {
         updateCampaignContent,
       } as unknown as HtmlEditorApiClient;
 
-      // Act
       renderEditor(
         <QueryClientProvider client={createQueryClient()}>
           <AppServicesProvider
@@ -312,11 +302,12 @@ describe(Campaign.name, () => {
         </QueryClientProvider>
       );
 
-      // Assert
       const buttonWithSave = await screen.findByText(buttonText);
 
+      // Act
       act(() => buttonWithSave.click());
 
+      // Assert
       await waitFor(() => {
         expect(updateCampaignContent).toHaveBeenCalledWith(idCampaign, {
           design,
@@ -344,16 +335,18 @@ describe(Campaign.name, () => {
     async ({ buttonText, urlExpected, searchParams }) => {
       // Arrange
       const initialEntries = `/idCampaign?${searchParams}`;
-      // Act
       renderEditor(
         <DoubleEditorWithStateLoaded initialEntries={[initialEntries]} />
       );
 
-      // Assert
       const buttonByText: HTMLAnchorElement = await screen.findByText(
         buttonText
       );
+
+      // Act
       await userEvent.click(buttonByText);
+
+      // Assert
       expect(setHref).toHaveBeenCalledWith(urlExpected);
     }
   );
@@ -378,13 +371,16 @@ describe(Campaign.name, () => {
     async ({ buttonText, urlExpected, searchParams }) => {
       // Arrange
       const initialEntries = [`/idCampaign?${searchParams}`];
-      // Act
       renderEditor(
         <DoubleEditorWithStateLoaded initialEntries={initialEntries} />
       );
-      // Assert
+
       const buttonByText = await screen.findByText(buttonText);
+
+      // Act
       await userEvent.click(buttonByText);
+
+      // Assert
       expect(setHref).toHaveBeenCalledWith(urlExpected);
     }
   );
@@ -407,18 +403,18 @@ describe(Campaign.name, () => {
     async ({ searchParams }) => {
       // Arrange
       const buttonText = "exit_edit_later";
-      //const urlExpected
-      const initialEntries = `/idCampaign?${searchParams}`;
 
-      // Act
+      const initialEntries = `/idCampaign?${searchParams}`;
       renderEditor(
         <DoubleEditorWithStateLoaded initialEntries={[initialEntries]} />
       );
 
-      // Assert
       const buttonByText = await screen.findByText(buttonText);
 
+      // Act
       await userEvent.click(buttonByText);
+
+      // Assert
       expect(setHref).toHaveBeenCalledWith(
         baseAppServices.appConfiguration.dopplerExternalUrls.campaigns
       );
@@ -426,22 +422,30 @@ describe(Campaign.name, () => {
   );
 
   it("export button must be disabled when is exporting as template", async () => {
-    // Act
+    // Arrange
     renderEditor(<DoubleEditorWithStateLoaded initialEntries={["/000"]} />);
 
     await waitFor(async () => {
       const exportToTemplate = await screen.findByText("save_template");
+
+      // Act
       act(() => exportToTemplate.click());
+
+      // Assert
       await waitFor(() => expect(exportToTemplate).toBeDisabled());
     });
   });
 
   it("export modal must open when click in export as template", async () => {
-    // Act
+    // Arrange
     renderEditor(<DoubleEditorWithStateLoaded initialEntries={["/000"]} />);
 
     const exportToTemplate = await screen.findByText("save_template");
+
+    // Act
     await act(() => exportToTemplate.click());
+
+    // Assert
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
     expect(exportToTemplate).toBeEnabled();
   });

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -8,7 +8,7 @@ import { AppServicesProvider } from "./AppServicesContext";
 import { Campaign, editorTopBarTestId, errorMessageTestId } from "./Campaign";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
 import { Design } from "react-email-editor";
-import { act, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import {
   ISingletonDesignContext,
   SingletonDesignContext,
@@ -305,16 +305,14 @@ describe(Campaign.name, () => {
       const buttonWithSave = await screen.findByText(buttonText);
 
       // Act
-      act(() => buttonWithSave.click());
+      await userEvent.click(buttonWithSave);
 
       // Assert
-      await waitFor(() => {
-        expect(updateCampaignContent).toHaveBeenCalledWith(idCampaign, {
-          design,
-          htmlContent,
-          previewImage: "",
-          type: "unlayer",
-        });
+      expect(updateCampaignContent).toHaveBeenCalledWith(idCampaign, {
+        design,
+        htmlContent,
+        previewImage: "",
+        type: "unlayer",
       });
     }
   );
@@ -425,15 +423,13 @@ describe(Campaign.name, () => {
     // Arrange
     renderEditor(<DoubleEditorWithStateLoaded initialEntries={["/000"]} />);
 
-    await waitFor(async () => {
-      const exportToTemplate = await screen.findByText("save_template");
+    const exportToTemplate = await screen.findByText("save_template");
 
-      // Act
-      act(() => exportToTemplate.click());
+    // Act
+    userEvent.click(exportToTemplate);
 
-      // Assert
-      await waitFor(() => expect(exportToTemplate).toBeDisabled());
-    });
+    // Assert
+    await waitFor(() => expect(exportToTemplate).toBeDisabled());
   });
 
   it("export modal must open when click in export as template", async () => {
@@ -443,10 +439,10 @@ describe(Campaign.name, () => {
     const exportToTemplate = await screen.findByText("save_template");
 
     // Act
-    await act(() => exportToTemplate.click());
+    userEvent.click(exportToTemplate);
 
     // Assert
-    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    await screen.findByRole("dialog");
     expect(exportToTemplate).toBeEnabled();
   });
 });


### PR DESCRIPTION
Hi team!

I need to do some changes to campaign and template pages behavior related to smart save when the user exit.

I will need to update the tests, and after this refactoring, it will be easier for me and, if I am not wrong, for following code readers and editors.