### PR TITLE
DE-960 - Avoid redundant saving on exit when ato-save is in progress

### DIFF
--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -80,7 +80,8 @@ export const useSingletonEditor = (
       ]);
 
       const newerChangesSaved = currentUpdateCounter < savedCounter.current;
-      if (newerChangesSaved) {
+      const currentChangesSaved = currentUpdateCounter === savedCounter.current;
+      if (newerChangesSaved || (!force && currentChangesSaved)) {
         return;
       }
 

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -79,6 +79,11 @@ export const useSingletonEditor = (
         exportImage(),
       ]);
 
+      const newerChangesSaved = currentUpdateCounter < savedCounter.current;
+      if (newerChangesSaved) {
+        return;
+      }
+
       const content: Content = !htmlExport.design
         ? {
             htmlContent: htmlExport.html,
@@ -93,10 +98,8 @@ export const useSingletonEditor = (
             type: "unlayer",
           };
 
-      if (currentUpdateCounter >= savedCounter.current) {
-        savedCounter.current = currentUpdateCounter;
-        onSave(content);
-      }
+      savedCounter.current = currentUpdateCounter;
+      onSave(content);
     },
     // eslint-disable-next-line
     [editorState, ...deps]


### PR DESCRIPTION
When the auto-save is in progress and there are no new changes and the user exit from the editor, no new save should be done.

### Before the fix

https://user-images.githubusercontent.com/1157864/222213703-e94fcc75-d8c4-47bc-8274-378691cf0952.mp4

![image](https://user-images.githubusercontent.com/1157864/222213765-bde49fb5-bf7d-4d58-b6d8-40aad719c7d5.png)

### After the fix

https://user-images.githubusercontent.com/1157864/222213731-d27227ab-7dbb-462d-9488-c173a215fba9.mp4

![image](https://user-images.githubusercontent.com/1157864/222213823-6d8d76af-083c-4dfb-9dc5-c805643440e1.png)
