### PR TITLE
DE-904 - Resolve unlayer editor manifest

### DIFF
--- a/cspell-project-words.txt
+++ b/cspell-project-words.txt
@@ -36,6 +36,7 @@ entitize
 Liskov
 nofile
 webfonts
+entrypoints
 
 # our services and providers
 aspnet

--- a/src/abstractions/asset-manifest-client/index.ts
+++ b/src/abstractions/asset-manifest-client/index.ts
@@ -1,0 +1,9 @@
+import { Result } from "../common/result-types";
+
+export interface AssetManifestClient {
+  getEntrypoints: ({
+    manifestURL,
+  }: {
+    manifestURL: string;
+  }) => Promise<Result<string[]>>;
+}

--- a/src/abstractions/configuration.ts
+++ b/src/abstractions/configuration.ts
@@ -5,7 +5,6 @@ export type AppConfiguration = {
   readonly loginPageUrl: string;
   readonly unlayerProjectId: number;
   readonly unlayerEditorManifestUrl: string;
-  readonly loaderUrl: string;
   readonly unlayerCDN: string;
   readonly dopplerLegacyBaseUrl: string;
   readonly htmlEditorApiBaseUrl: string;

--- a/src/abstractions/services.ts
+++ b/src/abstractions/services.ts
@@ -4,6 +4,7 @@ import { AppConfigurationRenderer } from "./app-configuration-renderer";
 import { AppSessionStateAccessor, AppSessionStateMonitor } from "./app-session";
 import { HtmlEditorApiClient } from "./html-editor-api-client";
 import { DopplerRestApiClient } from "./doppler-rest-api-client";
+import { AssetManifestClient } from "./asset-manifest-client";
 
 // TODO: Determine if defining this type based on a list of types possible,
 // for example based on this type:
@@ -17,4 +18,5 @@ export type AppServices = {
   dopplerRestApiClient: DopplerRestApiClient;
   appSessionStateAccessor: AppSessionStateAccessor;
   appSessionStateMonitor: AppSessionStateMonitor;
+  assetManifestClient: AssetManifestClient;
 };

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -37,7 +37,6 @@ const baseAppServices = {
   appConfiguration: {
     unlayerProjectId: 12345,
     unlayerEditorManifestUrl: "unlayerEditorManifestUrl",
-    loaderUrl: "loaderUrl",
     dopplerLegacyBaseUrl,
     dopplerExternalUrls: {
       home: "https://dopplerexternalurls.home/",

--- a/src/components/Editor.test.tsx
+++ b/src/components/Editor.test.tsx
@@ -26,7 +26,6 @@ const sampleDesign: Design = {
 
 const unlayerProjectId = 12345;
 const unlayerEditorManifestUrl = "unlayerEditorManifestUrl";
-const loaderUrl = "loaderUrl";
 const unlayerUserId = "unlayerUserId";
 const unlayerUserSignature = "unlayerUserSignature";
 
@@ -66,7 +65,6 @@ describe(Editor.name, () => {
       appConfiguration: {
         unlayerProjectId,
         unlayerEditorManifestUrl,
-        loaderUrl,
       },
       appSessionStateAccessor: {
         getCurrentSessionState: () => authenticatedSession,
@@ -129,7 +127,6 @@ describe(Editor.name, () => {
         appConfiguration: {
           unlayerProjectId,
           unlayerEditorManifestUrl,
-          loaderUrl,
         },
         appSessionStateAccessor: {
           getCurrentSessionState: () => ({

--- a/src/components/SingletonEditor.test.tsx
+++ b/src/components/SingletonEditor.test.tsx
@@ -53,7 +53,6 @@ const defaultAppServices = {
   appConfiguration: {
     unlayerProjectId: 12345,
     unlayerEditorManifestUrl: "unlayerEditorManifestUrl",
-    loaderUrl: "loaderUrl",
   },
   appSessionStateAccessor: {
     getCurrentSessionState: () => ({

--- a/src/components/Template.test.tsx
+++ b/src/components/Template.test.tsx
@@ -25,7 +25,6 @@ const baseAppServices = {
   appConfiguration: {
     unlayerProjectId: 12345,
     unlayerEditorManifestUrl: "unlayerEditorManifestUrl",
-    loaderUrl: "loaderUrl",
     dopplerLegacyBaseUrl,
     dopplerExternalUrls: {
       home: "https://dopplerexternalurls.home/",

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -14,6 +14,7 @@ import { DummyHtmlEditorApiClient } from "./implementations/dummies/html-editor-
 import { HtmlEditorApiClientImpl } from "./implementations/HtmlEditorApiClientImpl";
 import { DummyDopplerRestApiClient } from "./implementations/dummies/doppler-rest-api-client";
 import { DopplerRestApiClientImpl } from "./implementations/DopplerRestApiClientImpl";
+import { MfeLoaderAssetManifestClientImpl } from "./implementations/MfeLoaderAssetManifestClientImpl";
 
 export const configureApp = (
   customConfiguration: Partial<AppConfiguration>
@@ -51,6 +52,8 @@ export const configureApp = (
       new DopplerSessionMfeAppSessionStateMonitor({
         window,
       }),
+    assetManifestClientFactory: ({ window }: AppServices) =>
+      new MfeLoaderAssetManifestClientImpl({ window }),
   };
 
   const dummyFactories: Partial<ServicesFactories> = {

--- a/src/default-configuration.ts
+++ b/src/default-configuration.ts
@@ -9,7 +9,6 @@ export const defaultAppConfiguration: AppConfiguration = {
   loginPageUrl: "/login",
   unlayerEditorManifestUrl:
     "https://cdn.fromdoppler.com/unlayer-editor/asset-manifest-v2.json",
-  loaderUrl: "https://cdn.fromdoppler.com/loader/v1/loader.js",
   unlayerCDN: "https://cdn.fromdoppler.com/unlayer-editor",
   unlayerProjectId: 32092,
   dopplerLegacyBaseUrl: "https://appint.fromdoppler.net",

--- a/src/implementations/MfeLoaderAssetManifestClientImpl.test.ts
+++ b/src/implementations/MfeLoaderAssetManifestClientImpl.test.ts
@@ -1,0 +1,33 @@
+import { MfeLoaderAssetManifestClientImpl } from "./MfeLoaderAssetManifestClientImpl";
+
+describe(MfeLoaderAssetManifestClientImpl.name, () => {
+  describe("getEntrypoints", () => {
+    it("should use assetServices as it is", async () => {
+      // Arrange
+      const manifestURL = "a";
+      const assetServicesResult = ["b", "c"];
+
+      const windowDouble = {
+        assetServices: {
+          getEntrypoints: jest.fn(),
+        },
+      };
+      windowDouble.assetServices.getEntrypoints.mockResolvedValue(
+        assetServicesResult
+      );
+
+      const sut = new MfeLoaderAssetManifestClientImpl({
+        window: windowDouble,
+      });
+
+      // Act
+      const result = await sut.getEntrypoints({ manifestURL });
+
+      // Assert
+      expect(windowDouble.assetServices.getEntrypoints).toBeCalledWith({
+        manifestURL,
+      });
+      expect(result).toEqual({ success: true, value: assetServicesResult });
+    });
+  });
+});

--- a/src/implementations/MfeLoaderAssetManifestClientImpl.ts
+++ b/src/implementations/MfeLoaderAssetManifestClientImpl.ts
@@ -1,0 +1,35 @@
+import { AssetManifestClient } from "../abstractions/asset-manifest-client";
+
+interface IAssetServices {
+  getEntrypoints({ manifestURL }: { manifestURL: string }): Promise<string[]>;
+}
+
+declare global {
+  interface Window {
+    // See https://github.com/FromDoppler/mfe-loader/
+    assetServices: IAssetServices;
+  }
+}
+
+export class MfeLoaderAssetManifestClientImpl implements AssetManifestClient {
+  private assetServices: IAssetServices;
+
+  constructor({
+    window: { assetServices },
+  }: {
+    window: {
+      assetServices: IAssetServices;
+    };
+  }) {
+    this.assetServices = assetServices;
+  }
+
+  public async getEntrypoints({
+    manifestURL,
+  }: {
+    manifestURL: string;
+  }): Promise<{ success: true; value: string[] }> {
+    const value = await this.assetServices.getEntrypoints({ manifestURL });
+    return { success: true, value };
+  }
+}

--- a/src/implementations/SingletonLazyAppServicesContainer.ts
+++ b/src/implementations/SingletonLazyAppServicesContainer.ts
@@ -57,4 +57,8 @@ export class SingletonLazyAppServicesContainer implements AppServices {
   get dopplerRestApiClient() {
     return this.singleton("dopplerRestApiClient");
   }
+
+  get assetManifestClient() {
+    return this.singleton("assetManifestClient");
+  }
 }

--- a/src/queries/unlayer-editor-extensions-entrypoints.tsx
+++ b/src/queries/unlayer-editor-extensions-entrypoints.tsx
@@ -1,0 +1,28 @@
+import { QueryFunction, useQuery } from "@tanstack/react-query";
+import { useAppServices } from "../components/AppServicesContext";
+
+export const useUnlayerEditorExtensionsEntrypoints = () => {
+  const {
+    assetManifestClient,
+    appConfiguration: { unlayerEditorManifestUrl },
+  } = useAppServices();
+
+  const queryKey = [unlayerEditorManifestUrl];
+
+  const queryFn: QueryFunction<string[], typeof queryKey> = async (context) => {
+    const [manifestURL] = context.queryKey;
+
+    const result = await assetManifestClient.getEntrypoints({ manifestURL });
+    return result.value;
+  };
+
+  const query = useQuery({
+    queryKey,
+    queryFn,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  return query;
+};


### PR DESCRIPTION
With these changes, we will get an advance of the new MFE Loader feature (see https://github.com/FromDoppler/mfe-loader/pull/104 and https://github.com/MakingSense/doppler-swarm/pull/730) and resolve the Unlayer Editor Extensions manifest here in place of delegate it to the Unlayer IFrame.

![image](https://user-images.githubusercontent.com/1157864/224788319-00c9c041-2ae7-4176-8f7c-684f178f4ae7.png)

It should improve the performance and is also a step to fix the thumbnail generation.