### PR TITLE
[DE-963] Cambio estilos case del texto en editor Unlayer

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -38,6 +38,15 @@ export interface EditorProps {
   hidden: boolean;
 }
 
+const customCss = `
+.blockbuilder-content-tool-name{
+  text-transform: lowercase;
+}
+.blockbuilder-content-tool-name:first-letter{
+  text-transform: uppercase;
+}
+`;
+
 export const Editor = ({
   setEditorState,
   hidden,
@@ -127,6 +136,7 @@ export const Editor = ({
     designTagsConfig: {
       delimiter: ["[[{", "}]]"],
     },
+    customCSS: [customCss],
     customJS: [
       `window["unlayer-extensions-configuration"] = {
         locale: "${intl.locale}",


### PR DESCRIPTION
Using only the first letter uppercase in the unlayer tools name
![image](https://user-images.githubusercontent.com/6733401/224848898-3a0d3353-5546-48f4-acf3-b9ee083f7b35.png)

Related to: [DE-963](https://makingsense.atlassian.net/browse/DE-963)

[DE-963]: https://makingsense.atlassian.net/browse/DE-963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ