### PR TITLE
Replace underscore by lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "@testing-library/user-event": "14.4.3",
     "@types/history": "5.0.0",
     "@types/jest": "29.5.1",
+    "@types/lodash": "4.14.194",
     "@types/node": "18.16.5",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",
     "@types/react-modal": "^3.13.1",
     "@types/react-query": "1.2.9",
-    "@types/underscore": "1.11.4",
     "cspell": "6.31.1",
     "eclint": "2.8.1",
     "prettier": "2.8.8"
@@ -26,6 +26,7 @@
     "@tanstack/react-query": "4.29.5",
     "axios": "1.4.0",
     "history": "5.3.0",
+    "lodash": "4.17.21",
     "react": "18.2.0",
     "react-cool-onclickoutside": "1.7.0",
     "react-dom": "18.2.0",
@@ -35,7 +36,6 @@
     "react-router-dom": "6.11.1",
     "react-scripts": "5.0.1",
     "typescript": "5.0.4",
-    "underscore": "1.13.6",
     "web-vitals": "3.3.1"
   },
   "scripts": {

--- a/src/components/SingletonEditor.tsx
+++ b/src/components/SingletonEditor.tsx
@@ -9,7 +9,7 @@ import {
 import { UnlayerEditorWrapper } from "./UnlayerEditorWrapper";
 import { HtmlExport, ImageExport } from "react-email-editor";
 import { Content, UnlayerContent } from "../abstractions/domain/content";
-import { debounce } from "underscore";
+import { debounce } from "lodash";
 import { UnlayerEditorObject } from "../abstractions/domain/editor";
 
 export interface ISingletonDesignContext {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,6 +2142,11 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@4.14.194":
+  version "4.14.194"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
+  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
+
 "@types/node@*":
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
@@ -2242,11 +2247,6 @@
   version "2.0.2"
   resolved "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
-
-"@types/underscore@1.11.4":
-  version "1.11.4"
-  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.4.tgz#62e393f8bc4bd8a06154d110c7d042a93751def3"
-  integrity sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -7164,9 +7164,9 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
@@ -10215,11 +10215,6 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
-
-underscore@1.13.6:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
-  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I am replacing Underscore with Lodash because Jest fake timers were not working.

I wanted to use [this solution](https://stackoverflow.com/questions/52695553/testing-debounced-function-in-react-component-with-jest-and-enzyme#answer-64336022) in a test, but it does not work with Underscore, I suppose that it is related to [this issue](https://github.com/jashkenas/underscore/issues/2918).