### PR TITLE
Editor state's refactoring - step 1/2

### DIFF
--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -9,7 +9,7 @@ import { Campaign, editorTopBarTestId, errorMessageTestId } from "./Campaign";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
 import { Design } from "react-email-editor";
 import { act, screen, waitFor } from "@testing-library/react";
-import { SingletonDesignContext } from "./SingletonEditor";
+import { SingletonDesignContextProvider } from "./singleton-editor/singletonDesignContext";
 import userEvent from "@testing-library/user-event";
 import { Result } from "../abstractions/common/result-types";
 import { CampaignContent } from "../abstractions/domain/content";
@@ -145,13 +145,13 @@ const createTestContext = () => {
         }}
       >
         <TestDopplerIntlProvider>
-          <SingletonDesignContext.Provider value={singletonEditorContext}>
+          <SingletonDesignContextProvider value={singletonEditorContext}>
             <MemoryRouter initialEntries={[routerInitialEntry]}>
               <Routes>
                 <Route path="/:idCampaign" element={<Campaign />} />
               </Routes>
             </MemoryRouter>
-          </SingletonDesignContext.Provider>
+          </SingletonDesignContextProvider>
         </TestDopplerIntlProvider>
       </AppServicesProvider>
     </QueryClientProvider>

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -9,10 +9,7 @@ import { Campaign, editorTopBarTestId, errorMessageTestId } from "./Campaign";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
 import { Design } from "react-email-editor";
 import { act, screen, waitFor } from "@testing-library/react";
-import {
-  ISingletonDesignContext,
-  SingletonDesignContext,
-} from "./SingletonEditor";
+import { SingletonDesignContext } from "./SingletonEditor";
 import userEvent from "@testing-library/user-event";
 import { Result } from "../abstractions/common/result-types";
 import { CampaignContent } from "../abstractions/domain/content";
@@ -111,7 +108,7 @@ const createTestContext = () => {
     Promise.resolve({ url: editorExportedImageUrl, design: {} as Design });
 
   let simulateEditorChangeEvent = null as any;
-  const singletonEditorContext: ISingletonDesignContext = {
+  const singletonEditorContext = {
     hidden: false,
     setContent: () => {},
     unlayerEditorObject: {

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router-dom";
-import { useSingletonEditor } from "./SingletonEditor";
+import { useSingletonEditor } from "./singleton-editor";
 import { EditorTopBar } from "./EditorTopBar";
 import {
   useGetCampaignContent,

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -13,7 +13,7 @@ import { LoadingScreen } from "./LoadingScreen";
 import { useCampaignContinuationUrls } from "./continuation-urls";
 import { FormattedMessage } from "react-intl";
 import { SaveAsTemplateModal } from "./SaveAsTemplateModal";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useNavigateSmart } from "./smart-urls";
 import { SavingMessage } from "./SavingMessage";
 
@@ -32,16 +32,24 @@ export const Campaign = () => {
   }>;
 
   const campaignContentQuery = useGetCampaignContent(idCampaign);
-  const campaignContentMutation = useUpdateCampaignContent();
+  const {
+    mutateAsync: updateCampaignContentMutateAsync,
+    isLoading: UpdateCampaignContentIsLoading,
+  } = useUpdateCampaignContent();
+
+  const onSave = useCallback(
+    async (content: Content) => {
+      await updateCampaignContentMutateAsync({ idCampaign, content });
+    },
+    [updateCampaignContentMutateAsync, idCampaign]
+  );
 
   const { smartSave, exportContent } = useSingletonEditor(
     {
       initialContent: campaignContentQuery.data,
-      onSave: async (content: Content) => {
-        await campaignContentMutation.mutateAsync({ idCampaign, content });
-      },
+      onSave,
     },
-    [campaignContentQuery.data, campaignContentMutation.mutate, idCampaign]
+    [campaignContentQuery.data, onSave]
   );
 
   const continuationUrls = useCampaignContinuationUrls(idCampaign);
@@ -123,7 +131,7 @@ export const Campaign = () => {
           </Header>
           <Footer>
             <EditorBottomBar>
-              <SavingMessage show={campaignContentMutation.isLoading} />
+              <SavingMessage show={UpdateCampaignContentIsLoading} />
               <button
                 onClick={() => saveAndNavigateClick(continuationUrls.exitUrl)}
                 className="dp-button button-medium secondary-green"

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -72,6 +72,10 @@ export const Campaign = () => {
     setIsExportingAsTemplate(true);
     try {
       const content = await exportContent();
+      if (content?.type !== "unlayer") {
+        console.error("Only Unlayer contents can be saved as templates");
+        return;
+      }
       setContentToExportAsTemplate(content);
       setIsExportAsTemplateModalOpen(true);
     } finally {

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -73,8 +73,8 @@ export const Campaign = () => {
     try {
       const content = await exportContent();
       setContentToExportAsTemplate(content);
-    } finally {
       setIsExportAsTemplateModalOpen(true);
+    } finally {
       setIsExportingAsTemplate(false);
     }
   };

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from "react-router-dom";
 import "./Main.css";
-import { SingletonEditorProvider } from "./SingletonEditor";
+import { SingletonEditorProvider } from "./singleton-editor";
 
 export const mainTestId = "outlet-test-id";
 

--- a/src/components/Template.test.tsx
+++ b/src/components/Template.test.tsx
@@ -5,13 +5,9 @@ import { AppServices } from "../abstractions";
 import { HtmlEditorApiClient } from "../abstractions/html-editor-api-client";
 import { AppServicesProvider } from "./AppServicesContext";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { editorTopBarTestId, errorMessageTestId, Template } from "./Template";
-import {
-  ISingletonDesignContext,
-  SingletonDesignContext,
-} from "./SingletonEditor";
-import userEvent from "@testing-library/user-event";
+import { SingletonDesignContext } from "./SingletonEditor";
 import { Result } from "../abstractions/common/result-types";
 import { TemplateContent } from "../abstractions/domain/content";
 import { Design } from "react-email-editor";
@@ -98,7 +94,7 @@ const createTestContext = () => {
   const exportImageAsync = () =>
     Promise.resolve({ url: editorExportedImageUrl, design: {} as Design });
 
-  const singletonEditorContext: ISingletonDesignContext = {
+  const singletonEditorContext = {
     hidden: false,
     setContent: () => {},
     unlayerEditorObject: {

--- a/src/components/Template.test.tsx
+++ b/src/components/Template.test.tsx
@@ -7,7 +7,7 @@ import { AppServicesProvider } from "./AppServicesContext";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
 import { screen } from "@testing-library/react";
 import { editorTopBarTestId, errorMessageTestId, Template } from "./Template";
-import { SingletonDesignContext } from "./SingletonEditor";
+import { SingletonDesignContextProvider } from "./singleton-editor/singletonDesignContext";
 import { Result } from "../abstractions/common/result-types";
 import { TemplateContent } from "../abstractions/domain/content";
 import { Design } from "react-email-editor";
@@ -122,13 +122,13 @@ const createTestContext = () => {
         }}
       >
         <TestDopplerIntlProvider>
-          <SingletonDesignContext.Provider value={singletonEditorContext}>
+          <SingletonDesignContextProvider value={singletonEditorContext}>
             <MemoryRouter initialEntries={[routerInitialEntry]}>
               <Routes>
                 <Route path="/:idTemplate" element={<Template />} />
               </Routes>
             </MemoryRouter>
-          </SingletonDesignContext.Provider>
+          </SingletonDesignContextProvider>
         </TestDopplerIntlProvider>
       </AppServicesProvider>
     </QueryClientProvider>

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router-dom";
-import { useSingletonEditor } from "./SingletonEditor";
+import { useSingletonEditor } from "./singleton-editor";
 import { EditorTopBar } from "./EditorTopBar";
 import { useGetTemplate, useUpdateTemplate } from "../queries/template-queries";
 import { Header } from "./Header";

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -11,6 +11,7 @@ import { useTemplatesContinuationUrls } from "./continuation-urls";
 import { FormattedMessage } from "react-intl";
 import { useNavigateSmart } from "./smart-urls";
 import { SavingMessage } from "./SavingMessage";
+import { useCallback } from "react";
 
 export const errorMessageTestId = "error-message";
 export const editorTopBarTestId = "editor-top-bar-message";
@@ -23,28 +24,36 @@ export const Template = () => {
   const navigateSmart = useNavigateSmart();
 
   const templateQuery = useGetTemplate(idTemplate);
-  const templateMutation = useUpdateTemplate();
+  const {
+    mutateAsync: updateTemplateMutateAsync,
+    isLoading: updateTemplateIsLoading,
+  } = useUpdateTemplate();
+
+  const onSave = useCallback(
+    async (content: Content) => {
+      if (!templateQuery.data) {
+        console.error(
+          "Template data is not available trying to save template content",
+          content
+        );
+      } else if (content.type !== "unlayer") {
+        console.error("Content type is not supported", content);
+      } else {
+        await updateTemplateMutateAsync({
+          idTemplate,
+          template: { ...templateQuery.data, ...content },
+        });
+      }
+    },
+    [templateQuery.data, updateTemplateMutateAsync, idTemplate]
+  );
 
   const { smartSave } = useSingletonEditor(
     {
       initialContent: templateQuery.data,
-      onSave: async (content: Content) => {
-        if (!templateQuery.data) {
-          console.error(
-            "Template data is not available trying to save template content",
-            content
-          );
-        } else if (content.type !== "unlayer") {
-          console.error("Content type is not supported", content);
-        } else {
-          await templateMutation.mutateAsync({
-            idTemplate,
-            template: { ...templateQuery.data, ...content },
-          });
-        }
-      },
+      onSave,
     },
-    [templateQuery.data, templateMutation.mutate, idTemplate]
+    [templateQuery.data, onSave]
   );
 
   const saveAndNavigateClick = async (to: string) => {
@@ -78,7 +87,7 @@ export const Template = () => {
           </Header>
           <Footer>
             <EditorBottomBar>
-              <SavingMessage show={templateMutation.isLoading} />
+              <SavingMessage show={updateTemplateIsLoading} />
               <button
                 onClick={() => saveAndNavigateClick(continuationUrls.exitUrl)}
                 className="dp-button button-medium secondary-green"

--- a/src/components/singleton-editor/SingletonEditorProvider.test.tsx
+++ b/src/components/singleton-editor/SingletonEditorProvider.test.tsx
@@ -1,13 +1,13 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { AppServices } from "../abstractions";
-import { SingletonEditorProvider, useSingletonEditor } from "./SingletonEditor";
-import { AppServicesProvider } from "./AppServicesContext";
+import { AppServices } from "../../abstractions";
+import { SingletonEditorProvider, useSingletonEditor } from ".";
+import { AppServicesProvider } from "../AppServicesContext";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Field } from "../abstractions/doppler-rest-api-client";
-import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
-import { CampaignContent, Content } from "../abstractions/domain/content";
+import { Field } from "../../abstractions/doppler-rest-api-client";
+import { TestDopplerIntlProvider } from "../i18n/TestDopplerIntlProvider";
+import { CampaignContent, Content } from "../../abstractions/domain/content";
 import { useEffect, useState } from "react";
-import { UnlayerEditorObject } from "../abstractions/domain/editor";
+import { UnlayerEditorObject } from "../../abstractions/domain/editor";
 
 let exportHtmlData: any = {
   design: {},
@@ -46,7 +46,7 @@ const DoubleUnlayerEditorWrapper = ({
   return <div style={containerStyle} {...otherProps} />;
 };
 
-jest.mock("./UnlayerEditorWrapper", () => {
+jest.mock("../UnlayerEditorWrapper", () => {
   return { UnlayerEditorWrapper: DoubleUnlayerEditorWrapper };
 });
 

--- a/src/components/singleton-editor/SingletonEditorProvider.tsx
+++ b/src/components/singleton-editor/SingletonEditorProvider.tsx
@@ -2,10 +2,7 @@ import { useEffect, useState } from "react";
 import { UnlayerEditorWrapper } from "../UnlayerEditorWrapper";
 import { Content } from "../../abstractions/domain/content";
 import { UnlayerEditorObject } from "../../abstractions/domain/editor";
-import {
-  ISingletonDesignContext,
-  SingletonDesignContextProvider,
-} from "./singletonDesignContext";
+import { SingletonDesignContextProvider } from "./singletonDesignContext";
 
 const emptyDesign = {
   body: {
@@ -59,7 +56,7 @@ export const SingletonEditorProvider = ({
     }
   }, [content, unlayerEditorObject]);
 
-  const defaultContext: ISingletonDesignContext = {
+  const defaultContext = {
     hidden,
     setContent,
     unlayerEditorObject,

--- a/src/components/singleton-editor/SingletonEditorProvider.tsx
+++ b/src/components/singleton-editor/SingletonEditorProvider.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { UnlayerEditorWrapper } from "../UnlayerEditorWrapper";
+import { Content } from "../../abstractions/domain/content";
+import { UnlayerEditorObject } from "../../abstractions/domain/editor";
+import {
+  ISingletonDesignContext,
+  SingletonDesignContextProvider,
+} from "./singletonDesignContext";
+
+const emptyDesign = {
+  body: {
+    rows: [],
+  },
+};
+
+export const SingletonEditorProvider = ({
+  children,
+  ...props
+}: {
+  children: React.ReactNode;
+}) => {
+  const [content, setContent] = useState<Content | undefined>();
+  const hidden = !content;
+  const [unlayerEditorObject, setUnlayerEditorObject] = useState<
+    UnlayerEditorObject | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (unlayerEditorObject) {
+      if (!content) {
+        unlayerEditorObject.loadDesign(emptyDesign);
+        return;
+      }
+
+      if (content.type === "unlayer") {
+        unlayerEditorObject.loadDesign(content.design);
+        return;
+      }
+
+      if (content.type === "html") {
+        // Ugly patch because of:
+        // * https://github.com/unlayer/react-email-editor/issues/212
+        // * https://unlayer.canny.io/bug-reports/p/loaddesign-doesnt-reload-for-legacy-templates
+        unlayerEditorObject.loadDesign(emptyDesign);
+
+        // See https://examples.unlayer.com/web/legacy-template
+        unlayerEditorObject.loadDesign({
+          html: content.htmlContent,
+          classic: true,
+        } as any);
+        return;
+      }
+
+      throw new Error(
+        `Not implemented: Content type '${
+          (content as any).type
+        }' is not supported yet.`
+      );
+    }
+  }, [content, unlayerEditorObject]);
+
+  const defaultContext: ISingletonDesignContext = {
+    hidden,
+    setContent,
+    unlayerEditorObject,
+  };
+
+  return (
+    <SingletonDesignContextProvider value={defaultContext}>
+      {children}
+      <UnlayerEditorWrapper
+        setUnlayerEditorObject={setUnlayerEditorObject}
+        hidden={hidden}
+        {...props}
+      />
+    </SingletonDesignContextProvider>
+  );
+};

--- a/src/components/singleton-editor/index.ts
+++ b/src/components/singleton-editor/index.ts
@@ -1,0 +1,2 @@
+export { SingletonEditorProvider } from "./SingletonEditorProvider";
+export { useSingletonEditor } from "./useSingletonEditor";

--- a/src/components/singleton-editor/singletonDesignContext.ts
+++ b/src/components/singleton-editor/singletonDesignContext.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from "react";
+import { Content } from "../../abstractions/domain/content";
+import { UnlayerEditorObject } from "../../abstractions/domain/editor";
+
+export interface ISingletonDesignContext {
+  hidden: boolean;
+  setContent: (c: Content | undefined) => void;
+  unlayerEditorObject: UnlayerEditorObject | undefined;
+}
+
+const singletonDesignContext = createContext<ISingletonDesignContext>({
+  hidden: true,
+  setContent: () => {},
+  unlayerEditorObject: undefined,
+});
+
+export const SingletonDesignContextProvider = singletonDesignContext.Provider;
+
+export const useSingletonDesignContext = () =>
+  useContext(singletonDesignContext);

--- a/src/components/singleton-editor/singletonDesignContext.ts
+++ b/src/components/singleton-editor/singletonDesignContext.ts
@@ -2,13 +2,11 @@ import { createContext, useContext } from "react";
 import { Content } from "../../abstractions/domain/content";
 import { UnlayerEditorObject } from "../../abstractions/domain/editor";
 
-export interface ISingletonDesignContext {
+const singletonDesignContext = createContext<{
   hidden: boolean;
   setContent: (c: Content | undefined) => void;
   unlayerEditorObject: UnlayerEditorObject | undefined;
-}
-
-const singletonDesignContext = createContext<ISingletonDesignContext>({
+}>({
   hidden: true,
   setContent: () => {},
   unlayerEditorObject: undefined,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,3 +27,6 @@ export const promisifyProps = <TOut>(
   }
   return obj as TOut;
 };
+
+export const noop = () => {};
+export const noopAsync = () => Promise.resolve(undefined);


### PR DESCRIPTION
Hi team!

As I already mentioned in #526, I am in the way of refactoring SingletonEditor's state:

* Use reducer-based state in place of refs
* Split files and behavior
* Add tests

This is the first step. I am only moving files, renaming things, etc. Nothing in the behavior should be changed.

After this, I will create a new PR with the real refactoring (and a slight change in the behavior) 

Oh, I have also done two minor fixes related to export as template functionality.