### PR TITLE
Avoid double request after upload file

### DIFF
--- a/src/queries/image-gallery-queries.tsx
+++ b/src/queries/image-gallery-queries.tsx
@@ -34,7 +34,9 @@ export const useUploadImage = () => {
       return dopplerLegacyClient.uploadImage(file);
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries(queryKey);
+      // Resetting the query with searchTerm = "" to avoid double request after
+      // cleaning search input.
+      return queryClient.invalidateQueries([...queryKey, ""]);
     },
     onError: (error: Error) =>
       console.error(


### PR DESCRIPTION
After uploading items, we are cleaning the search terms to ensure to show the newly uploaded item.

It was generating two requests in place of one:

https://github.com/FromDoppler/doppler-editors-webapp/assets/1157864/e34aaaf4-c174-4fb5-b0b0-9470cca9122e

Now, it is fixed:

https://github.com/FromDoppler/doppler-editors-webapp/assets/1157864/53070716-2ae4-4d5f-ab49-6b799bef6a7c

