### PR TITLE
DOP-1418 - Promo codes

### DIFF
--- a/src/abstractions/common/result-types.ts
+++ b/src/abstractions/common/result-types.ts
@@ -1,8 +1,11 @@
 type SuccessResult<TResult> = TResult extends void
   ? { success: true }
-  : { success: true; value: TResult };
+  : { success: true; value: Readonly<TResult> };
 
-type ErrorResult<TExpectedError> = { success: false; error: TExpectedError };
+type ErrorResult<TExpectedError> = {
+  success: false;
+  error: Readonly<TExpectedError>;
+};
 
 export type Result<
   TResult = void,

--- a/src/abstractions/doppler-legacy-client/index.ts
+++ b/src/abstractions/doppler-legacy-client/index.ts
@@ -10,6 +10,18 @@ export type UploadImageError =
   | { reason: "unexpected"; details: unknown };
 export type UploadImageResult = Result<void, UploadImageError>;
 
+export type PromoCodeItem = {
+  code: string;
+  type: "percent" | "money";
+  value: number;
+  startDate: Date | undefined;
+  endDate: Date | undefined;
+  useLimit: number | undefined;
+  minPaymentAmount: number;
+  promotionName: string;
+  isActive: boolean;
+};
+
 export interface DopplerLegacyClient {
   getImageGallery: ({
     searchTerm,
@@ -27,4 +39,9 @@ export interface DopplerLegacyClient {
   uploadImage: (file: File) => Promise<UploadImageResult>;
   deleteImages: (items: readonly { name: string }[]) => Promise<Result>;
   getEditorSettings: () => Promise<Result<DopplerEditorSettings>>;
+  getPromoCodes: ({
+    store,
+  }: {
+    store: string;
+  }) => Promise<Result<PromoCodeItem[]>>;
 }

--- a/src/abstractions/editor-extensions-bridge/index.ts
+++ b/src/abstractions/editor-extensions-bridge/index.ts
@@ -1,0 +1,6 @@
+export interface EditorExtensionsBridge {
+  registerListener<TParameters, TResult>(
+    listenedAction: string,
+    workerFunction: (parameters: TParameters) => Promise<TResult>,
+  ): { destructor: () => void };
+}

--- a/src/abstractions/editor-extensions-listeners/index.ts
+++ b/src/abstractions/editor-extensions-listeners/index.ts
@@ -1,0 +1,3 @@
+export interface EditorExtensionsListeners {
+  registerListeners(): void;
+}

--- a/src/abstractions/services.ts
+++ b/src/abstractions/services.ts
@@ -7,6 +7,7 @@ import { DopplerRestApiClient } from "./doppler-rest-api-client";
 import { AssetManifestClient } from "./asset-manifest-client";
 import { DopplerLegacyClient } from "./doppler-legacy-client";
 import { EditorExtensionsBridge } from "./editor-extensions-bridge";
+import { EditorExtensionsListeners } from "./editor-extensions-listeners";
 
 // TODO: Determine if defining this type based on a list of types possible,
 // for example based on this type:
@@ -23,4 +24,5 @@ export type AppServices = {
   appSessionStateMonitor: AppSessionStateMonitor;
   assetManifestClient: AssetManifestClient;
   editorExtensionsBridge: EditorExtensionsBridge;
+  editorExtensionsListeners: EditorExtensionsListeners;
 };

--- a/src/abstractions/services.ts
+++ b/src/abstractions/services.ts
@@ -6,6 +6,7 @@ import { HtmlEditorApiClient } from "./html-editor-api-client";
 import { DopplerRestApiClient } from "./doppler-rest-api-client";
 import { AssetManifestClient } from "./asset-manifest-client";
 import { DopplerLegacyClient } from "./doppler-legacy-client";
+import { EditorExtensionsBridge } from "./editor-extensions-bridge";
 
 // TODO: Determine if defining this type based on a list of types possible,
 // for example based on this type:
@@ -21,4 +22,5 @@ export type AppServices = {
   appSessionStateAccessor: AppSessionStateAccessor;
   appSessionStateMonitor: AppSessionStateMonitor;
   assetManifestClient: AssetManifestClient;
+  editorExtensionsBridge: EditorExtensionsBridge;
 };

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -48,7 +48,7 @@ const baseAppServices = {
   dopplerRestApiClient: {
     getFields: () => Promise.resolve({ success: true, value: [] as Field[] }),
   },
-} as AppServices;
+} as unknown as AppServices;
 
 const createQueryClient = () =>
   new QueryClient({

--- a/src/components/singleton-editor/SingletonEditorProvider.test.tsx
+++ b/src/components/singleton-editor/SingletonEditorProvider.test.tsx
@@ -97,7 +97,7 @@ describe(`${SingletonEditorProvider.name}`, () => {
   });
 
   // Arrange
-  const appServices = defaultAppServices as AppServices;
+  const appServices = defaultAppServices as unknown as AppServices;
 
   const DemoComponent = ({ onSave }: { onSave: () => Promise<void> }) => {
     const [initialContent, setInitialContent] = useState<Content | undefined>();

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -48,11 +48,8 @@ export const configureApp = (
         appSessionStateAccessor,
         appConfiguration,
       }),
-    dopplerLegacyClientFactory: ({ axiosStatic, appConfiguration }) =>
-      new DopplerLegacyClientImpl({
-        axiosStatic,
-        appConfiguration,
-      }),
+    dopplerLegacyClientFactory: (appServices) =>
+      new DopplerLegacyClientImpl(appServices),
     appSessionStateAccessorFactory: ({ window }: AppServices) =>
       new DopplerSessionMfeAppSessionStateAccessor({ window }),
     appSessionStateMonitorFactory: ({ window }: AppServices) =>

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -17,6 +17,7 @@ import { DopplerRestApiClientImpl } from "./implementations/DopplerRestApiClient
 import { MfeLoaderAssetManifestClientImpl } from "./implementations/MfeLoaderAssetManifestClientImpl";
 import { DopplerLegacyClientImpl } from "./implementations/DopplerLegacyClientImpl";
 import { DummyDopplerLegacyClient } from "./implementations/dummies/doppler-legacy-client";
+import { EditorExtensionsBridgeImplementation } from "./implementations/editor-extensions-bridge";
 
 export const configureApp = (
   customConfiguration: Partial<AppConfiguration>,
@@ -58,6 +59,8 @@ export const configureApp = (
       }),
     assetManifestClientFactory: ({ window }: AppServices) =>
       new MfeLoaderAssetManifestClientImpl({ window }),
+    editorExtensionsBridgeFactory: (appServices) =>
+      new EditorExtensionsBridgeImplementation(appServices),
   };
 
   const dummyFactories: Partial<ServicesFactories> = {

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -18,6 +18,7 @@ import { MfeLoaderAssetManifestClientImpl } from "./implementations/MfeLoaderAss
 import { DopplerLegacyClientImpl } from "./implementations/DopplerLegacyClientImpl";
 import { DummyDopplerLegacyClient } from "./implementations/dummies/doppler-legacy-client";
 import { EditorExtensionsBridgeImplementation } from "./implementations/editor-extensions-bridge";
+import { EditorExtensionsListenersImplementation } from "./implementations/editor-extensions-listeners";
 
 export const configureApp = (
   customConfiguration: Partial<AppConfiguration>,
@@ -61,6 +62,8 @@ export const configureApp = (
       new MfeLoaderAssetManifestClientImpl({ window }),
     editorExtensionsBridgeFactory: (appServices) =>
       new EditorExtensionsBridgeImplementation(appServices),
+    editorExtensionsListenersFactory: (appServices) =>
+      new EditorExtensionsListenersImplementation(appServices),
   };
 
   const dummyFactories: Partial<ServicesFactories> = {

--- a/src/implementations/DopplerLegacyClientImpl.ts
+++ b/src/implementations/DopplerLegacyClientImpl.ts
@@ -9,6 +9,8 @@ import {
 import { ImageItem } from "../abstractions/domain/image-gallery";
 import { DopplerEditorSettings } from "../abstractions/domain/DopplerEditorSettings";
 
+const MERCADO_SHOPS_STORE_NAME = "MercadoShops";
+
 export class DopplerLegacyClientImpl implements DopplerLegacyClient {
   private axios;
   private window;
@@ -143,7 +145,7 @@ export class DopplerLegacyClientImpl implements DopplerLegacyClient {
   }
 }
 
-const INTEGRATIONS_WITH_PROMOTIONS = ["MercadoShops"];
+const INTEGRATIONS_WITH_PROMOTIONS = [MERCADO_SHOPS_STORE_NAME];
 
 function parseDopplerEditorSettings(data: unknown): DopplerEditorSettings {
   // See:

--- a/src/implementations/SingletonLazyAppServicesContainer.ts
+++ b/src/implementations/SingletonLazyAppServicesContainer.ts
@@ -69,4 +69,8 @@ export class SingletonLazyAppServicesContainer implements AppServices {
   get editorExtensionsBridge() {
     return this.singleton("editorExtensionsBridge");
   }
+
+  get editorExtensionsListeners() {
+    return this.singleton("editorExtensionsListeners");
+  }
 }

--- a/src/implementations/SingletonLazyAppServicesContainer.ts
+++ b/src/implementations/SingletonLazyAppServicesContainer.ts
@@ -65,4 +65,8 @@ export class SingletonLazyAppServicesContainer implements AppServices {
   get assetManifestClient() {
     return this.singleton("assetManifestClient");
   }
+
+  get editorExtensionsBridge() {
+    return this.singleton("editorExtensionsBridge");
+  }
 }

--- a/src/implementations/dummies/doppler-legacy-client.tsx
+++ b/src/implementations/dummies/doppler-legacy-client.tsx
@@ -142,4 +142,48 @@ export class DummyDopplerLegacyClient implements DopplerLegacyClient {
     console.log("End getEditorSettings", value);
     return { success: true, value } as const;
   };
+
+  getPromoCodes = async ({ store }: { store: string }) => {
+    if (store !== "MercadoShops") {
+      return { success: true, value: [] } as const;
+    }
+    return {
+      success: true,
+      value: [
+        {
+          code: `${store}-CODE-1`,
+          type: "money",
+          value: 1000,
+          useLimit: 1,
+          minPaymentAmount: 1,
+          startDate: new Date(2023, 0, 1),
+          endDate: new Date(2025, 0, 1),
+          promotionName: "Promotion 1",
+          isActive: true,
+        },
+        {
+          code: `${store}-CODE-2`,
+          type: "percent",
+          value: 15,
+          useLimit: 2,
+          minPaymentAmount: 2,
+          startDate: new Date(2023, 0, 1),
+          endDate: new Date(2025, 0, 1),
+          promotionName: "Promotion 2",
+          isActive: true,
+        },
+        {
+          code: `${store}-CODE-3`,
+          type: "money",
+          value: 500,
+          useLimit: 3,
+          minPaymentAmount: 3,
+          startDate: new Date(2023, 0, 1),
+          endDate: new Date(2025, 0, 1),
+          promotionName: "Another promotion",
+          isActive: true,
+        },
+      ],
+    } as const;
+  };
 }

--- a/src/implementations/editor-extensions-bridge/index.test.ts
+++ b/src/implementations/editor-extensions-bridge/index.test.ts
@@ -1,0 +1,196 @@
+import { EditorExtensionsBridgeImplementation } from ".";
+import { AppServices } from "../../abstractions";
+import { waitFor } from "@testing-library/react";
+
+const UNLAYER_ORIGIN = "https://editor.unlayer.com";
+
+const createTestContext = () => {
+  const windowDouble = {
+    addEventListener: jest.fn<any, [string, (p: any) => any], any>(),
+    removeEventListener: jest.fn<any, [string, (p: any) => any], any>(),
+    document: {
+      getElementsByTagName: jest.fn(() => [] as any[]),
+    },
+  };
+  const appServices = { window: windowDouble } as unknown as AppServices;
+  const sut = new EditorExtensionsBridgeImplementation(appServices);
+  const actionName = "getSomething";
+  const workerFunction = jest.fn();
+  const registerListener = () =>
+    sut.registerListener(actionName, workerFunction);
+  const getLastRegisteredListener = () =>
+    windowDouble.addEventListener.mock.calls.slice(-1)[0][1];
+  const getLastRemovedListener = () =>
+    windowDouble.removeEventListener.mock.calls.slice(-1)[0][1];
+
+  return {
+    windowDouble,
+    actionName,
+    registerListener,
+    workerFunction,
+    getLastRegisteredListener,
+    getLastRemovedListener,
+  };
+};
+
+describe(EditorExtensionsBridgeImplementation.name, () => {
+  describe("registerListener", () => {
+    it("should add a window's message event listener", () => {
+      // Arrange
+      const { windowDouble, registerListener } = createTestContext();
+
+      // Act
+      registerListener();
+
+      // Assert
+      expect(windowDouble.addEventListener).toBeCalledWith(
+        "message",
+        expect.any(Function),
+      );
+    });
+
+    it("should return a destructor that removes the listener", () => {
+      // Arrange
+      const {
+        registerListener,
+        getLastRegisteredListener,
+        getLastRemovedListener,
+      } = createTestContext();
+
+      // Act
+      const { destructor } = registerListener();
+
+      // Assert
+      expect(destructor).toBeDefined();
+
+      // Act
+      destructor();
+
+      // Assert
+      expect(getLastRemovedListener()).toBe(getLastRegisteredListener());
+    });
+  });
+
+  describe("registeredListener", () => {
+    it("should do nothing when origin is not unlayer", () => {
+      // Arrange
+      const {
+        registerListener,
+        workerFunction,
+        getLastRegisteredListener,
+        actionName,
+      } = createTestContext();
+      registerListener();
+      const registeredListener = getLastRegisteredListener()!;
+
+      // Act
+      registeredListener({
+        origin: "WRONG ORIGIN",
+        data: { action: actionName },
+      });
+
+      // Assert
+      expect(workerFunction).not.toBeCalled();
+    });
+
+    it("should do nothing when action is not the registered one", () => {
+      // Arrange
+      const { registerListener, workerFunction, getLastRegisteredListener } =
+        createTestContext();
+      registerListener();
+      const registeredListener = getLastRegisteredListener()!;
+
+      // Act
+      registeredListener({
+        origin: UNLAYER_ORIGIN,
+        data: { action: "WRONG ACTION NAME" },
+      });
+
+      // Assert
+      expect(workerFunction).not.toBeCalled();
+    });
+
+    it("should call registered function", () => {
+      // Arrange
+      const {
+        registerListener,
+        workerFunction,
+        getLastRegisteredListener,
+        actionName,
+      } = createTestContext();
+      registerListener();
+      const registeredListener = getLastRegisteredListener()!;
+
+      // Act
+      registeredListener({
+        origin: UNLAYER_ORIGIN,
+        data: { action: actionName },
+      });
+
+      // Assert
+      expect(workerFunction).toBeCalled();
+    });
+
+    it("should send registered function result to all frames", async () => {
+      // Arrange
+      const {
+        windowDouble,
+        registerListener,
+        workerFunction,
+        getLastRegisteredListener,
+        actionName,
+      } = createTestContext();
+      registerListener();
+      const requestId = 123;
+      const registeredListener = getLastRegisteredListener()!;
+      const workerFunctionResult = "workerFunctionResult";
+      workerFunction.mockResolvedValue(workerFunctionResult);
+      const frame1 = {
+        src: `${UNLAYER_ORIGIN}/url1`,
+        contentWindow: {
+          postMessage: jest.fn(),
+        },
+      };
+      const frame2 = {
+        src: `${UNLAYER_ORIGIN}/url2`,
+        contentWindow: {
+          postMessage: jest.fn(),
+        },
+      };
+      windowDouble.document.getElementsByTagName.mockReturnValue([
+        frame1,
+        frame2,
+      ]);
+
+      // Act
+      registeredListener({
+        origin: UNLAYER_ORIGIN,
+        data: { action: actionName, requestId },
+      });
+
+      // Assert
+      expect(workerFunction).toBeCalled();
+      await waitFor(() => {
+        expect(windowDouble.document.getElementsByTagName).toBeCalledWith(
+          "iframe",
+        );
+      });
+      expect(frame1.contentWindow.postMessage).toBeCalledWith(
+        {
+          isResponse: true,
+          requestId: requestId,
+          value: workerFunctionResult,
+        },
+        { targetOrigin: "*" },
+      );
+      expect(frame2.contentWindow.postMessage).toBeCalledWith(
+        {
+          isResponse: true,
+          requestId: requestId,
+          value: workerFunctionResult,
+        },
+        { targetOrigin: "*" },
+      );
+    });
+  });
+});

--- a/src/implementations/editor-extensions-bridge/index.ts
+++ b/src/implementations/editor-extensions-bridge/index.ts
@@ -1,0 +1,58 @@
+import { AppServices } from "../../abstractions";
+import { EditorExtensionsBridge } from "../../abstractions/editor-extensions-bridge";
+
+const UNLAYER_ORIGIN = "https://editor.unlayer.com";
+
+export class EditorExtensionsBridgeImplementation
+  implements EditorExtensionsBridge
+{
+  window: Window & typeof globalThis;
+
+  constructor({ window }: AppServices) {
+    this.window = window;
+  }
+
+  registerListener<TParameters, TResult>(
+    listenedAction: string,
+    workerFunction: (parameters: TParameters) => Promise<TResult>,
+  ) {
+    const listener = async ({
+      origin,
+      data,
+    }: MessageEvent<{ action: string; requestId: number } & TParameters>) => {
+      if (origin !== UNLAYER_ORIGIN) {
+        return;
+      }
+
+      if (listenedAction !== data.action) {
+        return;
+      }
+
+      const result = await workerFunction(data);
+
+      // I do not know how to identify the right iframe,
+      // sending the message to all of them.
+      Array.from(this.window.document.getElementsByTagName("iframe"))
+        .filter((x) => x.src.startsWith(UNLAYER_ORIGIN) && x.contentWindow)
+        .map((x) => x.contentWindow!)
+        .forEach((x) => {
+          x.postMessage(
+            {
+              isResponse: true,
+              requestId: data.requestId,
+              value: result,
+            },
+            { targetOrigin: "*" },
+          );
+        });
+    };
+
+    this.window.addEventListener("message", listener);
+
+    const destructor = () => {
+      this.window.removeEventListener("message", listener);
+    };
+
+    return { destructor };
+  }
+}

--- a/src/implementations/editor-extensions-listeners/index.test.ts
+++ b/src/implementations/editor-extensions-listeners/index.test.ts
@@ -1,0 +1,78 @@
+import { EditorExtensionsListenersImplementation } from ".";
+import { AppServices } from "../../abstractions";
+
+function createTestContext() {
+  const editorExtensionsBridge = {
+    registerListener: jest.fn(),
+  };
+
+  const dopplerLegacyClient = {
+    getPromoCodes: jest.fn(),
+  };
+
+  const appServices = {
+    editorExtensionsBridge,
+    dopplerLegacyClient,
+  } as unknown as AppServices;
+
+  const sut = new EditorExtensionsListenersImplementation(appServices);
+
+  const getFirstRegisteredListener = () =>
+    editorExtensionsBridge.registerListener.mock.calls[0][1];
+
+  return {
+    dependencies: { dopplerLegacyClient, editorExtensionsBridge },
+    sut,
+    getFirstRegisteredListener,
+  };
+}
+
+describe(EditorExtensionsListenersImplementation.name, () => {
+  describe("registerListeners", () => {
+    it("should register listener for getPromoCodes", () => {
+      // Arrange
+      const {
+        dependencies: { editorExtensionsBridge },
+        sut,
+      } = createTestContext();
+
+      // Act
+      sut.registerListeners();
+
+      // Assert
+      expect(editorExtensionsBridge.registerListener).toBeCalledWith(
+        "getPromoCodes",
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe("getPromoCodes Listener", () => {
+    it("should use dopplerLegacyClient", async () => {
+      // Arrange
+      const {
+        dependencies: { dopplerLegacyClient },
+        sut,
+        getFirstRegisteredListener,
+      } = createTestContext();
+
+      const dopplerLegacyClientResult = { value: "promo codes result" };
+      dopplerLegacyClient.getPromoCodes.mockResolvedValue(
+        dopplerLegacyClientResult,
+      );
+
+      sut.registerListeners();
+
+      const listener = getFirstRegisteredListener();
+
+      const store = "store";
+
+      // Act
+      const result = await listener({ store });
+
+      // Assert
+      expect(result).toBe(dopplerLegacyClientResult.value);
+      expect(dopplerLegacyClient.getPromoCodes).toBeCalledWith({ store });
+    });
+  });
+});

--- a/src/implementations/editor-extensions-listeners/index.ts
+++ b/src/implementations/editor-extensions-listeners/index.ts
@@ -1,0 +1,21 @@
+import { AppServices } from "../../abstractions";
+import { DopplerLegacyClient } from "../../abstractions/doppler-legacy-client";
+import { EditorExtensionsBridge } from "../../abstractions/editor-extensions-bridge";
+import { EditorExtensionsListeners } from "../../abstractions/editor-extensions-listeners";
+
+export class EditorExtensionsListenersImplementation
+  implements EditorExtensionsListeners
+{
+  editorExtensionsBridge: EditorExtensionsBridge;
+  dopplerLegacyClient: DopplerLegacyClient;
+
+  constructor({ editorExtensionsBridge, dopplerLegacyClient }: AppServices) {
+    this.editorExtensionsBridge = editorExtensionsBridge;
+    this.dopplerLegacyClient = dopplerLegacyClient;
+  }
+
+  // TODO: support unregister the listeners
+
+  registerListeners(): void {
+  }
+}

--- a/src/implementations/editor-extensions-listeners/index.ts
+++ b/src/implementations/editor-extensions-listeners/index.ts
@@ -17,5 +17,12 @@ export class EditorExtensionsListenersImplementation
   // TODO: support unregister the listeners
 
   registerListeners(): void {
+    this.editorExtensionsBridge.registerListener(
+      "getPromoCodes",
+      async ({ store }: { store: string }) => {
+        const result = await this.dopplerLegacyClient.getPromoCodes({ store });
+        return result.value;
+      },
+    );
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,9 @@ const appServices = configureApp(customConfiguration);
 const appSessionStateMonitor = appServices.appSessionStateMonitor;
 appSessionStateMonitor.start();
 
+const editorExtensionsListeners = appServices.editorExtensionsListeners;
+editorExtensionsListeners.registerListeners();
+
 const queryClient = new QueryClient();
 
 const container = document.getElementById(


### PR DESCRIPTION
In this PR we are adding a listener for the `getPromoCodes` message, asking the backend for the data, and returning the result to the editor's extensions following the convention defined in https://github.com/FromDoppler/unlayer-editor/pull/927

- [x] I need to add the tests before merging