### PR TITLE
DOP-1483 - Hide send test button

### DIFF
--- a/src/components/UnlayerEditorWrapper.tsx
+++ b/src/components/UnlayerEditorWrapper.tsx
@@ -141,7 +141,7 @@ export const UnlayerEditorWrapper = ({
     },
     displayMode: "email",
     features: {
-      sendTestEmail: true,
+      sendTestEmail: false,
       preheaderText: false,
       smartMergeTags: false,
       undoRedo: false, // it only hides the buttons, undo/redo still works


### PR DESCRIPTION
Hide send test email button on preview modal

![image](https://github.com/FromDoppler/doppler-editors-webapp/assets/83654756/bb121555-9c07-4344-8b04-ffb41eb7fdf5)
