### PR TITLE
DOP-1399 - Product gallery hide dropdown

### DIFF
--- a/src/components/base-gallery/SidePanel.tsx
+++ b/src/components/base-gallery/SidePanel.tsx
@@ -41,7 +41,10 @@ export const SidePanel = ({
   return loading ? (
     <ContentLoading />
   ) : (
-    <div className="dp-product-gallery-side-panel" style={{ width: "230px" }}>
+    <div
+      className="dp-product-gallery-side-panel "
+      style={{ width: "240px", paddingRight: "25px" }}
+    >
       <strong>
         <FormattedMessage id="my_integrations" />
       </strong>

--- a/src/components/product-gallery/HeaderSortProductsDropdown.tsx
+++ b/src/components/product-gallery/HeaderSortProductsDropdown.tsx
@@ -68,7 +68,7 @@ export const HeaderSortProductsDropdown = ({
     );
   }, [storeSelected]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return (
+  return storeSelected?.sortingProductsCriteria.length > 0 ? (
     <FieldGroupItem className="col-fixed--240">
       <Dropdown
         value={defaultSortingValue}
@@ -88,5 +88,7 @@ export const HeaderSortProductsDropdown = ({
         ))}
       </Dropdown>
     </FieldGroupItem>
+  ) : (
+    <></>
   );
 };


### PR DESCRIPTION
Hide Dropdown when a store or e-commerce has not sort support 

case no sort criteria without products
![image](https://github.com/FromDoppler/doppler-editors-webapp/assets/83654756/47f13b8d-87a2-4a2a-963f-f8f736bd82a8)

case with sort support with products
![image](https://github.com/FromDoppler/doppler-editors-webapp/assets/83654756/03bdb9af-94bd-42b9-bd8d-cce829498ee5)

case with sort support without products
![image](https://github.com/FromDoppler/doppler-editors-webapp/assets/83654756/e6e716e8-9af2-4c6a-90d8-770ddbb18891)
