### PR TITLE
DOP-1547- lock unlayer version

### DIFF
--- a/src/components/UnlayerEditorWrapper.tsx
+++ b/src/components/UnlayerEditorWrapper.tsx
@@ -145,6 +145,7 @@ export const UnlayerEditorWrapper = ({
       sort: false,
     },
     displayMode: "email",
+    version: "1.5.75",
     features: {
       sendTestEmail: false,
       preheaderText: false,


### PR DESCRIPTION
fix: set to 1.5.75 unlayer version

[docs](https://docs.unlayer.com/page/introducing-new-unlayer-editor#breaking-changes)