### PR TITLE
DOP-1575 - Replace unlayer preview

### DIFF
--- a/src/abstractions/doppler-legacy-client/index.ts
+++ b/src/abstractions/doppler-legacy-client/index.ts
@@ -46,6 +46,8 @@ export interface DopplerLegacyClient {
   >;
   uploadImage: (file: File) => Promise<UploadImageResult>;
   deleteImages: (items: readonly { name: string }[]) => Promise<Result>;
+  updateCampaignThumbnail: (idCampaign: string) => Promise<Result<void, any>>;
+  updateTemplateThumbnail: (idTemplate: string) => Promise<Result<void, any>>;
   getEditorSettings: (
     idCampaign?: string,
     idTemplate?: string,

--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -105,11 +105,9 @@ const createTestContext = () => {
 
   const editorDesign = { test: "Demo data" };
   const editorHtmlContent = "<html><p></p></html>";
-  const editorExportedImageUrl = "https://test.fromdoppler.net/export.png";
+  const defaultEditImageUrl = "https://cdn.fromdoppler.com/empty-300x240.jpg";
   const exportHtmlAsync = () =>
     Promise.resolve({ design: editorDesign, html: editorHtmlContent });
-  const exportImageAsync = () =>
-    Promise.resolve({ url: editorExportedImageUrl, design: {} });
 
   let simulateEditorChangeEvent = null as any;
   const singletonEditorContext = {
@@ -134,7 +132,6 @@ const createTestContext = () => {
         }
       },
       exportHtmlAsync,
-      exportImageAsync,
       registerCallback: noop,
       unregisterCallback: noop,
       canUndo: noop,
@@ -173,7 +170,7 @@ const createTestContext = () => {
   return {
     editorDesign,
     editorHtmlContent,
-    editorExportedImageUrl,
+    defaultEditImageUrl,
     getCampaignContent,
     updateCampaignContent,
     resolveGetCampaignContentPromise: (result: Result<CampaignContent>) =>
@@ -259,7 +256,7 @@ describe(Campaign.name, () => {
       const {
         editorDesign,
         editorHtmlContent,
-        editorExportedImageUrl,
+        defaultEditImageUrl,
         updateCampaignContent,
         resolveGetCampaignContentPromise,
         simulateEditorChangeEvent,
@@ -279,7 +276,7 @@ describe(Campaign.name, () => {
       expect(updateCampaignContent).toHaveBeenCalledWith(idCampaign, {
         design: editorDesign,
         htmlContent: editorHtmlContent,
-        previewImage: editorExportedImageUrl,
+        previewImage: defaultEditImageUrl,
         type: "unlayer",
       });
     },

--- a/src/components/Template.test.tsx
+++ b/src/components/Template.test.tsx
@@ -93,11 +93,10 @@ const createTestContext = () => {
 
   const editorDesign = { test: "Demo data" } as any;
   const editorHtmlContent = "<html><p></p></html>";
-  const editorExportedImageUrl = "https://test.fromdoppler.net/export.png";
+  const defaultPreviewImageUrl =
+    "https://cdn.fromdoppler.com/empty-300x240.jpg";
   const exportHtmlAsync = () =>
     Promise.resolve({ design: editorDesign, html: editorHtmlContent });
-  const exportImageAsync = () =>
-    Promise.resolve({ url: editorExportedImageUrl, design: {} as any });
 
   const singletonEditorContext = {
     hidden: false,
@@ -111,7 +110,6 @@ const createTestContext = () => {
       registerCallback: noop,
       unregisterCallback: noop,
       exportHtmlAsync,
-      exportImageAsync,
     },
   };
 
@@ -146,7 +144,7 @@ const createTestContext = () => {
   return {
     editorDesign,
     editorHtmlContent,
-    editorExportedImageUrl,
+    defaultPreviewImageUrl,
     getTemplate,
     updateTemplate,
     resolveGetTemplatePromise: (result: Result<TemplateContent>) =>

--- a/src/components/singleton-editor/SingletonEditorProvider.test.tsx
+++ b/src/components/singleton-editor/SingletonEditorProvider.test.tsx
@@ -186,7 +186,7 @@ describe(`${SingletonEditorProvider.name}`, () => {
       arbitrary: "data",
     };
     const htmlContent = "HTML";
-    const previewImage = "https://app.fromdoppler.net/image.png";
+    const previewImage = "https://cdn.fromdoppler.com/empty-300x240.jpg";
     exportHtmlData = {
       design,
       html: htmlContent,

--- a/src/components/singleton-editor/useGenerateThumbnail.ts
+++ b/src/components/singleton-editor/useGenerateThumbnail.ts
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import {
+  useUpdateCampaignThumbnail,
+  useUpdateTemplateThumbnail,
+} from "../../queries/campaign-content-queries";
+
+/*
+ * TODO:
+ *       - Add unit test
+ *       - Add flag hasChange to throw event
+ */
+
+export function useGenerateThumbnail({
+  global = window,
+}: {
+  global?: Window & typeof globalThis;
+}) {
+  const { mutate: updateTemplateThumbnail } = useUpdateTemplateThumbnail();
+  const { mutate: updateCampaignThumbnail } = useUpdateCampaignThumbnail();
+  const { idCampaign, idTemplate } = useParams() as Readonly<{
+    idCampaign: string;
+    idTemplate: string;
+  }>;
+  // When the user exit the editor generate thumbnail
+  useEffect(() => {
+    const beforeUnloadListener = (e: BeforeUnloadEvent) => {
+      if (idCampaign !== undefined && idCampaign !== "0") {
+        updateCampaignThumbnail({ idCampaign: idCampaign });
+      } else {
+        updateTemplateThumbnail({ idTemplate: idTemplate });
+      }
+      const confirmationMessage = "";
+      e.returnValue = confirmationMessage; // Gecko, Trident, Chrome 34+
+      return confirmationMessage; // Gecko, WebKit, Chrome <34
+    };
+
+    global.addEventListener("beforeunload", beforeUnloadListener);
+
+    return () =>
+      global.removeEventListener("beforeunload", beforeUnloadListener);
+  }, [
+    global,
+    idCampaign,
+    idTemplate,
+    updateTemplateThumbnail,
+    updateCampaignThumbnail,
+  ]);
+}

--- a/src/components/singleton-editor/useSaving.test.tsx
+++ b/src/components/singleton-editor/useSaving.test.tsx
@@ -110,7 +110,7 @@ describe(useSaving.name, () => {
 
       const exportedDesign = "design" as any;
       const exportedHtml = "html";
-      const exportedImageUrl = "url";
+      const exportedImageUrl = "https://cdn.fromdoppler.com/empty-300x240.jpg";
 
       render(<TestComponent />);
       const { unlayerEditorObject } = createUnlayerObjectDouble({
@@ -138,7 +138,7 @@ describe(useSaving.name, () => {
         createTestContext();
 
       const exportedHtml = "html";
-      const exportedImageUrl = "url";
+      const exportedImageUrl = "https://cdn.fromdoppler.com/empty-300x240.jpg";
 
       render(<TestComponent />);
       const { unlayerEditorObject } = createUnlayerObjectDouble({
@@ -219,7 +219,7 @@ describe(useSaving.name, () => {
 
       const exportedDesign = "design" as any;
       const exportedHtml = "html";
-      const exportedImageUrl = "url";
+      const exportedImageUrl = "https://cdn.fromdoppler.com/empty-300x240.jpg";
       const savingUpdateCounter = 10;
 
       render(<TestComponent />);
@@ -262,7 +262,7 @@ describe(useSaving.name, () => {
 
       const exportedDesign = "design" as any;
       const exportedHtml = "html";
-      const exportedImageUrl = "url";
+      const exportedImageUrl = "https://cdn.fromdoppler.com/empty-300x240.jpg";
       const savingUpdateCounter = 10;
       const error = "error";
 

--- a/src/components/singleton-editor/useSaving.ts
+++ b/src/components/singleton-editor/useSaving.ts
@@ -16,28 +16,18 @@ async function exportContentFromUnlayer(
     return;
   }
 
-  const [htmlExport, imageExport] = await Promise.all([
-    unlayerEditorObject.exportHtmlAsync(),
-    unlayerEditorObject.exportImageAsync().catch((e) => {
-      console.log("Error generating image", e);
-      return {
-        design: {},
-        url: "https://cdn.fromdoppler.com/empty-300x240.jpg",
-      };
-    }),
-  ]);
-
+  const htmlExport = await unlayerEditorObject.exportHtmlAsync();
+  // TODO Analyze keep previewImage data
   const content: Content = !htmlExport.design
     ? {
         htmlContent: htmlExport.html,
-        // TODO: validate if the generated image is valid for HTML content
-        previewImage: imageExport.url ?? "",
+        previewImage: "https://cdn.fromdoppler.com/empty-300x240.jpg",
         type: "html",
       }
     : {
         design: htmlExport.design,
         htmlContent: htmlExport.html,
-        previewImage: imageExport.url ?? "",
+        previewImage: "https://cdn.fromdoppler.com/empty-300x240.jpg",
         type: "unlayer",
       };
 

--- a/src/components/singleton-editor/useSingletonEditor.ts
+++ b/src/components/singleton-editor/useSingletonEditor.ts
@@ -9,6 +9,7 @@ import { useActionWhenNoPendingUpdates } from "./useActionWhenNoPendingUpdates";
 import { useMemo } from "react";
 import { useCustomMediaLibrarySetup } from "./useCustomMediaLibrarySetup";
 import { useEditorExtensionListeners } from "./useEditorExtensionListeners";
+import { useGenerateThumbnail } from "./useGenerateThumbnail";
 
 export type UndoToolsObject = Readonly<{
   canUndo: boolean;
@@ -67,6 +68,8 @@ export const useSingletonEditor = ({
     areUpdatesPending,
     smartSave,
   });
+
+  useGenerateThumbnail({});
 
   const { doWhenNoPendingUpdates } = useActionWhenNoPendingUpdates({
     areUpdatesPending,

--- a/src/implementations/DopplerLegacyClientImpl.ts
+++ b/src/implementations/DopplerLegacyClientImpl.ts
@@ -145,6 +145,46 @@ export class DopplerLegacyClientImpl implements DopplerLegacyClient {
     };
   }
 
+  async updateCampaignThumbnail(
+    idCampaign: string,
+  ): Promise<Result<void, any>> {
+    try {
+      // Using postForm to avoid the preflight request
+      const result = await this.axios.postForm(
+        "/Campaigns/Editor/GenerateCampaignThumbnail",
+        {
+          idCampaign: idCampaign,
+        },
+      );
+      if (!result.data.success) {
+        return { success: false, error: { cause: result.data } };
+      }
+    } catch (e) {
+      return { success: false, error: { cause: e } };
+    }
+    return { success: true };
+  }
+
+  async updateTemplateThumbnail(
+    idTemplate: string,
+  ): Promise<Result<void, any>> {
+    try {
+      // Using postForm to avoid the preflight request
+      const result = await this.axios.postForm(
+        "/Campaigns/Editor/GenerateTemplateThumbnail",
+        {
+          idTemplate: idTemplate,
+        },
+      );
+      if (!result.data.success) {
+        return { success: false, error: { cause: result.data } };
+      }
+    } catch (e) {
+      return { success: false, error: { cause: e } };
+    }
+    return { success: true };
+  }
+
   async getEditorSettings(idCampaign?: string, idTemplate?: string) {
     // fix to resolve call GetSettings with both parameter
     const _idTemplate = idCampaign && idCampaign !== "0" ? "0" : idTemplate;

--- a/src/implementations/dummies/doppler-legacy-client.tsx
+++ b/src/implementations/dummies/doppler-legacy-client.tsx
@@ -198,6 +198,22 @@ export class DummyDopplerLegacyClient implements DopplerLegacyClient {
       return { success: true };
     };
 
+  updateCampaignThumbnail: (idCampaign: string) => Promise<Result<void, any>> =
+    async (idCampaign) => {
+      console.log(`Begin updateCampaignThumbnail ${idCampaign}...`);
+      await timeout(1000);
+      console.log("End updateCampaignThumbnail");
+      return { success: true };
+    };
+
+  updateTemplateThumbnail: (idTemplate: string) => Promise<Result<void, any>> =
+    async (idTemplate) => {
+      console.log(`Begin updateTemplateThumbnail ${idTemplate}...`);
+      await timeout(1000);
+      console.log("End updateTemplateThumbnail");
+      return { success: true };
+    };
+
   getEditorSettings = async () => {
     console.log("Begin getEditorSettings...");
     await timeout(1000);

--- a/src/queries/campaign-content-queries.tsx
+++ b/src/queries/campaign-content-queries.tsx
@@ -37,6 +37,20 @@ export const useGetCampaignContent = (idCampaign: string) => {
   return query;
 };
 
+export const useUpdateCampaignThumbnail = () => {
+  const { dopplerLegacyClient } = useAppServices();
+  const updateCampaignThumbnail = ({ idCampaign }: { idCampaign: string }) =>
+    dopplerLegacyClient.updateCampaignThumbnail(idCampaign);
+  return useMutation(updateCampaignThumbnail);
+};
+
+export const useUpdateTemplateThumbnail = () => {
+  const { dopplerLegacyClient } = useAppServices();
+  const updateTemplateThumbnail = ({ idTemplate }: { idTemplate: string }) =>
+    dopplerLegacyClient.updateTemplateThumbnail(idTemplate);
+  return useMutation(updateTemplateThumbnail);
+};
+
 export const useUpdateCampaignContent = () => {
   const { htmlEditorApiClient } = useAppServices();
 


### PR DESCRIPTION
fix: replace request generate unlayer preview image by doppler generate thumb

Trouble: Each content update unlayer saves the change, in this procedure, call a method to generate a content image preview after that save the content with an image associate. That generates a new image impacting the s3 storage with unused image files. 
