### PR TITLE
DOP-1577 - Set image as campaign content from gallery

### DIFF
--- a/src/abstractions/doppler-legacy-client/index.ts
+++ b/src/abstractions/doppler-legacy-client/index.ts
@@ -16,7 +16,12 @@ export type SortingImagesDirection = "ASCENDING" | "DESCENDING";
 export type UploadImageError =
   | { reason: "maxSizeExceeded"; currentSize: number; maxSize: number }
   | { reason: "unexpected"; details: unknown };
+export type UnexpectedError = { reason: "unexpected"; details: unknown };
 export type UploadImageResult = Result<void, UploadImageError>;
+export type SetImageCampaign = Result<UploadImageSuccess, UnexpectedError>;
+export type UploadImageSuccess = {
+  url: string;
+};
 
 export type PromoCodeItem = {
   code: string;
@@ -45,6 +50,7 @@ export interface DopplerLegacyClient {
     Result<{ items: ImageItem[]; continuation: string | undefined }>
   >;
   uploadImage: (file: File) => Promise<UploadImageResult>;
+  selectGalleryImage: (fileName: string) => Promise<SetImageCampaign>;
   deleteImages: (items: readonly { name: string }[]) => Promise<Result>;
   updateCampaignThumbnail: (idCampaign: string) => Promise<Result<void, any>>;
   updateTemplateThumbnail: (idTemplate: string) => Promise<Result<void, any>>;

--- a/src/components/custom-media-library/CustomMediaLibraryModal.tsx
+++ b/src/components/custom-media-library/CustomMediaLibraryModal.tsx
@@ -7,6 +7,7 @@ import { useLibraryBehavior } from "./behavior";
 import { useConfirmationModal } from "../confirmation";
 import { useNotificationModal } from "../notification";
 import { ImageItem } from "../../abstractions/domain/image-gallery";
+import { useSelectGalleryImage } from "../../queries/campaign-content-queries";
 
 const CustomMediaLibrary = ({
   cancel,
@@ -49,12 +50,25 @@ export const useCustomMediaLibraryModal = () => {
   const [imageSelectedCallbackWrapper, setImageSelectedCallbackWrapper] =
     useState<{ callback: (data: { url: string }) => void }>({ callback: noop });
 
+  const { mutate: selectImageMutation } = useSelectGalleryImage();
   const [showModal, hideModal] = useModal(
     () => (
       <CustomMediaLibraryModal
         cancel={hideModal}
         selectItem={(data) => {
-          imageSelectedCallbackWrapper.callback(data);
+          const fileName = data.name as string;
+          selectImageMutation(fileName, {
+            onSuccess: (response) => {
+              imageSelectedCallbackWrapper.callback({
+                ...data,
+                url: response.value.url,
+              });
+            },
+            onError: (error) => {
+              imageSelectedCallbackWrapper.callback(data);
+              throw error;
+            },
+          });
           hideModal();
         }}
       />

--- a/src/implementations/DopplerLegacyClientImpl.ts
+++ b/src/implementations/DopplerLegacyClientImpl.ts
@@ -6,6 +6,7 @@ import {
   SortingImagesCriteria,
   SortingImagesDirection,
   UploadImageResult,
+  SetImageCampaign,
 } from "../abstractions/doppler-legacy-client";
 import { ImageItem } from "../abstractions/domain/image-gallery";
 import {
@@ -183,6 +184,31 @@ export class DopplerLegacyClientImpl implements DopplerLegacyClient {
       return { success: false, error: { cause: e } };
     }
     return { success: true };
+  }
+
+  async selectGalleryImage(fileName: string): Promise<SetImageCampaign> {
+    try {
+      const result = await this.axios.postForm(
+        "/Campaigns/Editor/selectGalleryImage",
+        {
+          imageName: fileName,
+        },
+      );
+      if (result.data?.success) {
+        return {
+          success: true,
+          value: {
+            url: result.data?.imageUrl || "",
+          },
+        };
+      }
+      return {
+        success: false,
+        error: { reason: "unexpected", details: result.data },
+      };
+    } catch (e) {
+      return { success: false, error: { reason: "unexpected", details: e } };
+    }
   }
 
   async getEditorSettings(idCampaign?: string, idTemplate?: string) {

--- a/src/implementations/dummies/doppler-legacy-client.tsx
+++ b/src/implementations/dummies/doppler-legacy-client.tsx
@@ -3,6 +3,7 @@ import {
   DopplerLegacyClient,
   SortingImagesCriteria,
   SortingImagesDirection,
+  SetImageCampaign,
   UploadImageResult,
 } from "../../abstractions/doppler-legacy-client";
 import { Result } from "../../abstractions/common/result-types";
@@ -182,6 +183,21 @@ export class DummyDopplerLegacyClient implements DopplerLegacyClient {
       success: false,
       error: { reason: "unexpected", details: { unexpected: "error" } },
     };
+  };
+
+  selectGalleryImage: (fileName: string) => Promise<SetImageCampaign> = async (
+    fileName,
+  ) => {
+    console.log("Begin select image for campaign ...");
+    console.log(fileName);
+    await timeout(1000);
+    console.log("End saving");
+    return {
+      success: true,
+      value: {
+        url: "https://dummyimage.com/300x150/000/fff.jpg&text=image%20shared",
+      },
+    } as const;
   };
 
   deleteImages: (items: readonly { name: string }[]) => Promise<Result> =

--- a/src/queries/campaign-content-queries.tsx
+++ b/src/queries/campaign-content-queries.tsx
@@ -44,6 +44,20 @@ export const useUpdateCampaignThumbnail = () => {
   return useMutation(updateCampaignThumbnail);
 };
 
+export const useSelectGalleryImage = () => {
+  const { dopplerLegacyClient } = useAppServices();
+
+  return useMutation({
+    mutationFn: async (fileName: string) => {
+      const result = await dopplerLegacyClient.selectGalleryImage(fileName);
+      if (!result.success) {
+        throw result.error;
+      }
+      return result;
+    },
+  });
+};
+
 export const useUpdateTemplateThumbnail = () => {
   const { dopplerLegacyClient } = useAppServices();
   const updateTemplateThumbnail = ({ idTemplate }: { idTemplate: string }) =>


### PR DESCRIPTION
Fix: set a gallery image as an image campaign

![image](https://github.com/FromDoppler/doppler-editors-webapp/assets/83654756/79e375d8-8fb8-4ef2-aa3e-e88984c4b010)
