### PR TITLE
DOP-1581 - Image campaign upload

### DIFF
--- a/src/abstractions/doppler-legacy-client/index.ts
+++ b/src/abstractions/doppler-legacy-client/index.ts
@@ -22,6 +22,10 @@ export type SetImageCampaign = Result<UploadImageSuccess, UnexpectedError>;
 export type UploadImageSuccess = {
   url: string;
 };
+export type UploadCampaignImageResult = Result<
+  UploadImageSuccess,
+  UploadImageError
+>;
 
 export type PromoCodeItem = {
   code: string;
@@ -50,6 +54,7 @@ export interface DopplerLegacyClient {
     Result<{ items: ImageItem[]; continuation: string | undefined }>
   >;
   uploadImage: (file: File) => Promise<UploadImageResult>;
+  uploadImageCampaign: (file: File) => Promise<UploadCampaignImageResult>;
   selectGalleryImage: (fileName: string) => Promise<SetImageCampaign>;
   deleteImages: (items: readonly { name: string }[]) => Promise<Result>;
   updateCampaignThumbnail: (idCampaign: string) => Promise<Result<void, any>>;

--- a/src/components/singleton-editor/useImageUploadSetup.test.tsx
+++ b/src/components/singleton-editor/useImageUploadSetup.test.tsx
@@ -1,0 +1,239 @@
+import { useState } from "react";
+import { act, render, waitFor, screen } from "@testing-library/react";
+import { TestDopplerIntlProvider } from "../i18n/TestDopplerIntlProvider";
+import { UnlayerEditorObject } from "../../abstractions/domain/editor";
+import { ModalProvider } from "react-modal-hook";
+import { useImageUploadSetup } from "./useImageUploadSetup";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AppServicesProvider } from "../AppServicesContext";
+
+type UploadImageDoneCallback = (data: {
+  url: string;
+  progress: number;
+}) => void;
+
+function createUnlayerObjectDouble() {
+  const registerCallback = jest.fn<
+    void,
+    [string, (data: object, done: UploadImageDoneCallback) => void]
+  >();
+  const unregisterCallback = jest.fn<void, [string]>();
+
+  return {
+    unlayerEditorObject: {
+      registerCallback: registerCallback as (
+        type: string,
+        callback: (data: object, done: UploadImageDoneCallback) => void,
+      ) => void,
+      unregisterCallback: unregisterCallback as (type: string) => void,
+    } as UnlayerEditorObject,
+    mocks: {
+      registerCallback,
+      unregisterCallback,
+    },
+  };
+}
+
+const queryClient = new QueryClient();
+
+const createTestContext = () => {
+  let currentSetUnlayerEditorObject: (
+    _: UnlayerEditorObject | undefined,
+  ) => void;
+
+  let currentUploadFileEnabled: boolean;
+  let currentSetImageUploadEnabled: (_: boolean) => void;
+
+  const TestComponent = ({ enabled }: { enabled?: boolean }) => {
+    const [unlayerEditorObject, setUnlayerEditorObject] =
+      useState<UnlayerEditorObject>();
+    currentSetUnlayerEditorObject = setUnlayerEditorObject;
+
+    const { imageUploadEnabled, setImageUploadEnabled } = useImageUploadSetup({
+      unlayerEditorObject,
+      enabled,
+    });
+    currentUploadFileEnabled = imageUploadEnabled;
+    currentSetImageUploadEnabled = setImageUploadEnabled;
+
+    return <></>;
+  };
+
+  return {
+    TestComponent,
+    setUnlayerEditorObject: (
+      unlayerEditorObject: UnlayerEditorObject | undefined,
+    ) => act(() => currentSetUnlayerEditorObject(unlayerEditorObject)),
+    getCurrentUploadFileEnabled: () => currentUploadFileEnabled,
+    setCustomUploadFileEnabled: (enabled: boolean) =>
+      act(() => currentSetImageUploadEnabled(enabled)),
+  };
+};
+
+describe(useImageUploadSetup.name, () => {
+  it("should register image unlayer callback as uploadImage and return done callback", async () => {
+    // Arrange
+    const dopplerLegacyClient = {
+      uploadImageCampaign: jest.fn((file) =>
+        Promise.resolve({
+          success: true,
+          value: {
+            url: `https://cdn.fromdoppler.com/${file.name}`,
+          },
+        }),
+      ),
+    };
+
+    const callback = jest.fn();
+    const {
+      TestComponent,
+      setUnlayerEditorObject,
+      getCurrentUploadFileEnabled,
+    } = createTestContext();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppServicesProvider appServices={{ dopplerLegacyClient } as any}>
+          <ModalProvider>
+            <TestComponent />
+          </ModalProvider>
+        </AppServicesProvider>
+      </QueryClientProvider>,
+    );
+    const {
+      unlayerEditorObject,
+      mocks: { registerCallback },
+    } = createUnlayerObjectDouble();
+    expect(registerCallback).not.toBeCalled();
+
+    // Act
+    setUnlayerEditorObject(unlayerEditorObject);
+
+    // Assert
+    expect(getCurrentUploadFileEnabled()).toBe(true);
+    expect(registerCallback).toBeCalledWith("image", expect.any(Function));
+
+    // Arrange
+    const onUploadImage = registerCallback.mock.calls[0][1];
+    const mockFile = new File(["file content"], "test.png", {
+      type: "image/png",
+    });
+
+    // Act
+    onUploadImage({ attachments: [mockFile] }, callback);
+
+    // Assert
+    await waitFor(() => {
+      expect(callback).toHaveBeenCalledWith({
+        url: "https://cdn.fromdoppler.com/test.png",
+        progress: 100,
+      });
+    });
+  });
+
+  it("should return callback done on upload error and show error modal", async () => {
+    // Arrange
+    const dopplerLegacyClient = {
+      uploadImageCampaign: jest.fn(() =>
+        Promise.resolve({
+          success: false,
+          error: { reason: "unexpected", details: "Error" },
+        }),
+      ),
+    };
+
+    const callback = jest.fn();
+    const { TestComponent, setUnlayerEditorObject } = createTestContext();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppServicesProvider appServices={{ dopplerLegacyClient } as any}>
+          <TestDopplerIntlProvider>
+            <ModalProvider>
+              <TestComponent />
+            </ModalProvider>
+          </TestDopplerIntlProvider>
+        </AppServicesProvider>
+      </QueryClientProvider>,
+    );
+    const {
+      unlayerEditorObject,
+      mocks: { registerCallback },
+    } = createUnlayerObjectDouble();
+
+    // Act
+    setUnlayerEditorObject(unlayerEditorObject);
+
+    // Arrange
+    const onUploadImage = registerCallback.mock.calls[0][1];
+    const mockFile = new File(["file content"], "test.png", {
+      type: "image/png",
+    });
+
+    // Act
+    onUploadImage({ attachments: [mockFile] }, callback);
+
+    // Assert
+    await waitFor(() => {
+      const modal = screen.getByRole("dialog");
+      expect(modal).toBeDefined();
+      const messageDescriptorId = screen.getByText(
+        "error_uploading_image_unexpected",
+      );
+      expect(messageDescriptorId).toBeDefined();
+
+      expect(callback).toHaveBeenCalledWith({
+        url: "https://cdn.tools.unlayer.com/image/placeholder.png",
+        progress: 100,
+      });
+    });
+  });
+
+  it("should normalize file name", async () => {
+    // Arrange
+    const dopplerLegacyClient = {
+      uploadImageCampaign: jest.fn((file) =>
+        Promise.resolve({
+          success: true,
+          value: {
+            url: `https://cdn.fromdoppler.com/${file.name}`,
+          },
+        }),
+      ),
+    };
+
+    const callback = jest.fn();
+    const { TestComponent, setUnlayerEditorObject } = createTestContext();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppServicesProvider appServices={{ dopplerLegacyClient } as any}>
+          <ModalProvider>
+            <TestComponent />
+          </ModalProvider>
+        </AppServicesProvider>
+      </QueryClientProvider>,
+    );
+    const {
+      unlayerEditorObject,
+      mocks: { registerCallback },
+    } = createUnlayerObjectDouble();
+
+    // Act
+    setUnlayerEditorObject(unlayerEditorObject);
+
+    // Arrange
+    const onUploadImage = registerCallback.mock.calls[0][1];
+    const mockFile = new File(["file content"], "normalize", {
+      type: "image/png",
+    });
+
+    // Act
+    onUploadImage({ attachments: [mockFile] }, callback);
+
+    // Assert
+    await waitFor(() => {
+      expect(callback).toHaveBeenCalledWith({
+        url: "https://cdn.fromdoppler.com/normalize.png",
+        progress: 100,
+      });
+    });
+  });
+});

--- a/src/components/singleton-editor/useImageUploadSetup.ts
+++ b/src/components/singleton-editor/useImageUploadSetup.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { UnlayerEditorObject } from "../../abstractions/domain/editor";
+import { useUploadImageCampaign } from "../../queries/campaign-content-queries";
+import { useNotificationModal } from "../notification";
+import { IntlMessageId } from "../../abstractions/i18n";
+
+export type NotificationProps = {
+  contentType?: "error";
+  titleDescriptorId: IntlMessageId;
+  messageDescriptorId: IntlMessageId;
+  closeButtonDescriptorId?: IntlMessageId;
+  values?: Record<string, any>;
+};
+
+export function useImageUploadSetup({
+  unlayerEditorObject,
+  enabled = true,
+}: {
+  unlayerEditorObject: UnlayerEditorObject | undefined;
+  enabled?: boolean;
+}) {
+  const [imageUploadEnabled, setImageUploadEnabled] = useState(enabled);
+  const { mutate: uploadImageMutation } = useUploadImageCampaign();
+  const { showNotificationModal } = useNotificationModal();
+
+  const normalizeName = (file: File): string => {
+    const etx = file.type.substring(6);
+    const fileName =
+      file.name.indexOf(etx) > 0 ? file.name : `${file.name}.${etx}`;
+    return fileName;
+  };
+
+  useEffect(() => {
+    if (!unlayerEditorObject || !imageUploadEnabled) {
+      return;
+    }
+    unlayerEditorObject.registerCallback(
+      "image",
+      function (file: any, done: any) {
+        const uploadFile = file.attachments[0];
+        if (uploadFile === undefined) {
+          const err = new Error("file not found");
+          throw err;
+        }
+
+        const blob = uploadFile.slice(0, file.size);
+        const newFile = new File([blob], normalizeName(uploadFile), {
+          type: uploadFile.type,
+        });
+
+        uploadImageMutation(newFile, {
+          onSuccess: (response) => {
+            done({
+              progress: 100,
+              url: response.value.url,
+            });
+          },
+          onError: (_, file) => {
+            const values = { filename: file.name };
+            const titleDescriptorId = "error_uploading_image";
+            const contentType = "error";
+            const messageDescriptorId = "error_uploading_image_unexpected";
+
+            showNotificationModal({
+              contentType,
+              titleDescriptorId,
+              messageDescriptorId,
+              values,
+            });
+            // TODO: wait unlayer resolve error callback
+            done({
+              progress: 100,
+              url: "https://cdn.tools.unlayer.com/image/placeholder.png",
+            });
+          },
+        });
+      },
+    );
+  }, [
+    unlayerEditorObject,
+    imageUploadEnabled,
+    uploadImageMutation,
+    showNotificationModal,
+  ]);
+
+  return {
+    imageUploadEnabled,
+    setImageUploadEnabled,
+  };
+}

--- a/src/components/singleton-editor/useSingletonEditor.ts
+++ b/src/components/singleton-editor/useSingletonEditor.ts
@@ -10,6 +10,7 @@ import { useMemo } from "react";
 import { useCustomMediaLibrarySetup } from "./useCustomMediaLibrarySetup";
 import { useEditorExtensionListeners } from "./useEditorExtensionListeners";
 import { useGenerateThumbnail } from "./useGenerateThumbnail";
+import { useImageUploadSetup } from "./useImageUploadSetup";
 
 export type UndoToolsObject = Readonly<{
   canUndo: boolean;
@@ -32,6 +33,12 @@ export const useSingletonEditor = ({
   });
   // Ugly patch to allow enable/disable custom media library
   (window as any).setCustomMediaLibraryEnabled = setCustomMediaLibraryEnabled;
+
+  const { setImageUploadEnabled } = useImageUploadSetup({
+    unlayerEditorObject,
+  });
+  // Ugly patch to allow enable/disable image upload library
+  (window as any).setImageUploadEnabled = setImageUploadEnabled;
 
   useEditorExtensionListeners();
 
@@ -58,6 +65,8 @@ export const useSingletonEditor = ({
     dispatch,
   });
 
+  useGenerateThumbnail({});
+
   useContentUpdatesDetection({
     dispatch,
     smartSave,
@@ -68,8 +77,6 @@ export const useSingletonEditor = ({
     areUpdatesPending,
     smartSave,
   });
-
-  useGenerateThumbnail({});
 
   const { doWhenNoPendingUpdates } = useActionWhenNoPendingUpdates({
     areUpdatesPending,

--- a/src/implementations/DopplerLegacyClientImpl.test.ts
+++ b/src/implementations/DopplerLegacyClientImpl.test.ts
@@ -297,6 +297,40 @@ describe(DopplerLegacyClientImpl.name, () => {
     });
   });
 
+  describe("uploadImageCampaign", () => {
+    it("Should request backend", async () => {
+      // Arrange
+      const dopplerLegacyBaseUrl = "dopplerLegacyBaseUrl";
+      const { sut, axiosCreate, axiosPostForm } = createTestContext({
+        dopplerLegacyBaseUrl,
+      });
+      const file = new File(["file content"], "test.png", {
+        type: "image/png",
+      }) as File;
+
+      // Act
+      const result = await sut.uploadImageCampaign(file);
+
+      // Assert
+      expect(axiosCreate).toBeCalledWith({
+        baseURL: dopplerLegacyBaseUrl,
+        withCredentials: true,
+      });
+      expect(axiosPostForm).toBeCalledWith(
+        "/Campaigns/Editor/UploadImageCampaign",
+        {
+          file,
+        },
+      );
+      expect(result).toEqual({
+        success: true,
+        value: {
+          url: "",
+        },
+      });
+    });
+  });
+
   describe("deleteImages", () => {
     it("should request backend", async () => {
       // Arrange

--- a/src/implementations/DopplerLegacyClientImpl.ts
+++ b/src/implementations/DopplerLegacyClientImpl.ts
@@ -7,6 +7,7 @@ import {
   SortingImagesDirection,
   UploadImageResult,
   SetImageCampaign,
+  UploadCampaignImageResult,
 } from "../abstractions/doppler-legacy-client";
 import { ImageItem } from "../abstractions/domain/image-gallery";
 import {
@@ -202,6 +203,43 @@ export class DopplerLegacyClientImpl implements DopplerLegacyClient {
           },
         };
       }
+      return {
+        success: false,
+        error: { reason: "unexpected", details: result.data },
+      };
+    } catch (e) {
+      return { success: false, error: { reason: "unexpected", details: e } };
+    }
+  }
+
+  async uploadImageCampaign(file: File): Promise<UploadCampaignImageResult> {
+    try {
+      const result = await this.axios.postForm(
+        "/Campaigns/Editor/UploadImageCampaign",
+        {
+          file,
+        },
+      );
+      if (result.data?.success) {
+        return {
+          success: true,
+          value: {
+            url: result.data?.imageUrl || "",
+          },
+        };
+      }
+
+      if (result.data && "maxSize" in result.data) {
+        return {
+          success: false,
+          error: {
+            reason: "maxSizeExceeded",
+            currentSize: file.size,
+            maxSize: result.data.maxSize,
+          },
+        };
+      }
+
       return {
         success: false,
         error: { reason: "unexpected", details: result.data },

--- a/src/implementations/dummies/doppler-legacy-client.tsx
+++ b/src/implementations/dummies/doppler-legacy-client.tsx
@@ -5,6 +5,7 @@ import {
   SortingImagesDirection,
   SetImageCampaign,
   UploadImageResult,
+  UploadCampaignImageResult,
 } from "../../abstractions/doppler-legacy-client";
 import { Result } from "../../abstractions/common/result-types";
 import { ImageItem } from "../../abstractions/domain/image-gallery";
@@ -199,6 +200,24 @@ export class DummyDopplerLegacyClient implements DopplerLegacyClient {
       },
     } as const;
   };
+
+  uploadImageCampaign: (file: File) => Promise<UploadCampaignImageResult> =
+    async (file) => {
+      console.log("Begin uploadImage...");
+      console.log(file);
+      await timeout(1000);
+      console.log("End uploadImage");
+      // return {
+      //   success: true,
+      //   value: {
+      //     url: "https://cdn.fromdoppler.com/empty-300x240.jpg",
+      //   },
+      // } as const;
+      return {
+        success: false,
+        error: { reason: "unexpected", details: { unexpected: "error" } },
+      };
+    };
 
   deleteImages: (items: readonly { name: string }[]) => Promise<Result> =
     async (items) => {

--- a/src/queries/campaign-content-queries.tsx
+++ b/src/queries/campaign-content-queries.tsx
@@ -79,6 +79,20 @@ export const useUpdateCampaignContent = () => {
   return useMutation(updateCampaignContent);
 };
 
+export const useUploadImageCampaign = () => {
+  const { dopplerLegacyClient } = useAppServices();
+
+  return useMutation({
+    mutationFn: async (file: File) => {
+      const result = await dopplerLegacyClient.uploadImageCampaign(file);
+      if (!result.success) {
+        throw result.error;
+      }
+      return result;
+    },
+  });
+};
+
 export const useUpdateCampaignContentFromTemplate = () => {
   const { htmlEditorApiClient } = useAppServices();
 


### PR DESCRIPTION
Fix: Add unlayer image callback

when the user adds an image from unlayer gallery, edits the image, or creates with IA this file is stored at Doppler system file.
 unlayer image callback [doc ](https://docs.unlayer.com/docs/custom-file-storage)

Note: the backend for images over 3 Mb does a compression process to reduce the size

![image](https://github.com/FromDoppler/doppler-editors-webapp/assets/83654756/ef452342-75b7-4363-97b4-43c08e62fac2)
When the endpoint throws an error, the callback returns https://cdn.tools.unlayer.com/image/placeholder.png as the image

error case: 
![image](https://github.com/FromDoppler/doppler-editors-webapp/assets/83654756/0b8d8ac0-bc70-4988-ad58-937eaef0b564)


TODO: watch unalyer release if add a error callback