### PR TITLE
DOP-1691 - Add prefix for template

### DIFF
--- a/src/components/singleton-editor/useImageUploadSetup.ts
+++ b/src/components/singleton-editor/useImageUploadSetup.ts
@@ -22,8 +22,9 @@ export function useImageUploadSetup({
   unlayerEditorObject: UnlayerEditorObject | undefined;
   enabled?: boolean;
 }) {
-  const { idCampaign } = useParams() as Readonly<{
+  const { idCampaign, idTemplate } = useParams() as Readonly<{
     idCampaign: string;
+    idTemplate: string;
   }>;
 
   const [imageUploadEnabled, setImageUploadEnabled] = useState(enabled);
@@ -44,7 +45,10 @@ export function useImageUploadSetup({
           const fileName = hasAcceptedExtension
             ? file.name
             : `${file.name}.${ext}`;
-          return idCampaign.concat("_" + fileName);
+          const id =
+            (idCampaign ? idCampaign : "template_".concat(idTemplate)) ||
+            "file";
+          return id.concat("_" + fileName);
         };
 
         const uploadFile = file.attachments[0];
@@ -97,6 +101,7 @@ export function useImageUploadSetup({
     uploadImageMutation,
     showNotificationModal,
     idCampaign,
+    idTemplate,
   ]);
 
   return {


### PR DESCRIPTION
Fix: add template prefix when an image is saved from a template

[DOP-1691](https://makingsense.atlassian.net/browse/DOP-1691)


issue

![image](https://github.com/user-attachments/assets/d4efcdf9-45e9-4e33-bf1f-5074988a700b)

resolve

![image](https://github.com/user-attachments/assets/1f4c3839-5581-41ba-b398-baf7d33c586b)




[DOP-1691]: https://makingsense.atlassian.net/browse/DOP-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ