### PR TITLE
DOP-1738 - Resolve document name for empty name (fix)

### DIFF
--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -91,8 +91,9 @@ export const Campaign = () => {
         console.error("Only Unlayer contents can be saved as templates");
         return;
       }
-      const filename = campaignContentQuery.data?.campaignName.concat(
-        "html",
+      const campaignName = campaignContentQuery.data?.campaignName.trim();
+      const filename = (
+        campaignName && campaignName !== "" ? campaignName : "campaign"
       ) as string;
       const blobContent = new Blob([content?.htmlContent || ""], {
         type: "text/html",

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -68,8 +68,9 @@ export const Template = () => {
         console.error("Only Unlayer contents can be saved as templates");
         return;
       }
-      const filename = templateQuery.data?.templateName.concat(
-        "html",
+      const templateName = templateQuery.data?.templateName.trim();
+      const filename = (
+        templateName && templateName !== "" ? templateName : "template"
       ) as string;
       const blobContent = new Blob([content?.htmlContent || ""], {
         type: "text/html",


### PR DESCRIPTION
Fix: resolve document name for empty name

[DOP-1738](https://makingsense.atlassian.net/browse/DOP-1738)

[DOP-1738]: https://makingsense.atlassian.net/browse/DOP-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ