### PR TITLE
fix: use infohtml instead info

### DIFF
--- a/src/abstractions/domain/product-gallery.ts
+++ b/src/abstractions/domain/product-gallery.ts
@@ -8,6 +8,6 @@ export type ProductGalleryValue = {
   discountText: string | undefined;
   descriptionHtml: string | undefined;
   reference?: string | undefined;
-  info?: string | undefined;
+  infoHtml?: string | undefined;
   source?: string | undefined;
 };

--- a/src/implementations/DopplerLegacyClientImpl.ts
+++ b/src/implementations/DopplerLegacyClientImpl.ts
@@ -487,7 +487,7 @@ function parseProductItem({
   DiscountText,
   DescriptionHtml,
   Reference,
-  Info,
+  InfoHtml,
 }: any) {
   return {
     productUrl: `${ProductUrl}`,
@@ -498,6 +498,6 @@ function parseProductItem({
     discountText: `${DiscountText}`,
     descriptionHtml: `${DescriptionHtml}`,
     reference: `${Reference}`,
-    info: `${Info}`,
+    infoHtml: `${InfoHtml}`,
   };
 }

--- a/src/implementations/dummies/doppler-legacy-client.tsx
+++ b/src/implementations/dummies/doppler-legacy-client.tsx
@@ -70,7 +70,7 @@ export const demoProducts: ProductGalleryValue[] = [
     discountText: "10% Off",
     descriptionHtml: "<p>Descripción del producto <b>product1</b></p>",
     reference: "reference",
-    info: "<p>Descripción del producto <b>product1</b></p>",
+    infoHtml: "<p>Descripción del producto <b>product1</b></p>",
   },
   {
     productUrl: "https://fromdoppler.net/product/product2",


### PR DESCRIPTION
With this fix, when we replace dynamic HTML content with product information, we can now display the ```InfoHtml```

![image](https://github.com/user-attachments/assets/9bc58cea-b86a-4a83-86b8-82dd7ae4d6f3)

