### PR TITLE
fix: generate template thumbnail after saving private template

### DIFF
--- a/src/components/SaveAsTemplateModal.test.tsx
+++ b/src/components/SaveAsTemplateModal.test.tsx
@@ -4,6 +4,31 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
 import userEvent from "@testing-library/user-event";
+import { AppServicesProvider } from "./AppServicesContext";
+
+const createAppServices = () => {
+  const createPrivateTemplate = jest.fn().mockResolvedValue({
+    success: true,
+    value: { newTemplateId: "new-template-id" },
+  });
+
+  const updateTemplateThumbnail = jest.fn().mockResolvedValue({
+    success: true,
+  });
+
+  return {
+    appServices: {
+      htmlEditorApiClient: {
+        createPrivateTemplate,
+      },
+      dopplerLegacyClient: {
+        updateTemplateThumbnail,
+      },
+    } as any,
+    createPrivateTemplate,
+    updateTemplateThumbnail,
+  };
+};
 
 const createQueryClient = () =>
   new QueryClient({
@@ -28,14 +53,16 @@ describe(SaveAsTemplateModal.name, () => {
     // Act
     render(
       <QueryClientProvider client={createQueryClient()}>
-        <TestDopplerIntlProvider>
-          <SaveAsTemplateModal
-            close={() => {}}
-            isOpen={true}
-            content={unlayerContent}
-            defaultName={defaultName}
-          />
-        </TestDopplerIntlProvider>
+        <AppServicesProvider appServices={createAppServices().appServices}>
+          <TestDopplerIntlProvider>
+            <SaveAsTemplateModal
+              close={() => {}}
+              isOpen={true}
+              content={unlayerContent}
+              defaultName={defaultName}
+            />
+          </TestDopplerIntlProvider>
+        </AppServicesProvider>
       </QueryClientProvider>,
     );
 
@@ -46,10 +73,7 @@ describe(SaveAsTemplateModal.name, () => {
     expect(inputName).toHaveValue(`${defaultName}-with-changes`);
   });
 
-  // TODO: fix this test
-  // I think that it is broken because htmlEditorApiClient is not defined when the mutation in
-  // the hook useCreatePrivateTemplate is executed.
-  it.skip("should be show the success message when click on accept button", async () => {
+  it("should create the template and generate its thumbnail", async () => {
     // Arrange
     const unlayerContent: UnlayerContent = {
       design: { test: "Demo data" } as any,
@@ -58,23 +82,43 @@ describe(SaveAsTemplateModal.name, () => {
       type: "unlayer",
     };
     const defaultName = "default-name";
+    const { appServices, createPrivateTemplate, updateTemplateThumbnail } =
+      createAppServices();
     // Act
     render(
       <QueryClientProvider client={createQueryClient()}>
-        <TestDopplerIntlProvider>
-          <SaveAsTemplateModal
-            close={() => {}}
-            isOpen={true}
-            content={unlayerContent}
-            defaultName={defaultName}
-          />
-        </TestDopplerIntlProvider>
+        <AppServicesProvider appServices={appServices}>
+          <TestDopplerIntlProvider>
+            <SaveAsTemplateModal
+              close={() => {}}
+              isOpen={true}
+              content={unlayerContent}
+              defaultName={defaultName}
+            />
+          </TestDopplerIntlProvider>
+        </AppServicesProvider>
       </QueryClientProvider>,
     );
 
     screen.getByRole("dialog");
     const submitButton = screen.getByText("save");
-    await act(() => userEvent.click(submitButton));
+    await act(async () => {
+      await userEvent.click(submitButton);
+    });
+
+    await waitFor(() =>
+      expect(createPrivateTemplate).toHaveBeenCalledWith({
+        design: unlayerContent.design,
+        htmlContent: unlayerContent.htmlContent,
+        previewImage: unlayerContent.previewImage,
+        type: "unlayer",
+        templateName: defaultName,
+        isPublic: false,
+      }),
+    );
+    await waitFor(() =>
+      expect(updateTemplateThumbnail).toHaveBeenCalledWith("new-template-id"),
+    );
     await waitFor(() => screen.getByText("new_template_has_been_saved"));
   });
 });

--- a/src/components/SaveAsTemplateModal.tsx
+++ b/src/components/SaveAsTemplateModal.tsx
@@ -4,6 +4,7 @@ import { useCreatePrivateTemplate } from "../queries/template-queries";
 import { UnlayerContent } from "../abstractions/domain/content";
 import { ChangeEvent, FormEvent, useState } from "react";
 import { useModal } from "react-modal-hook";
+import { useAppServices } from "./AppServicesContext";
 
 interface SaveAsTemplateModalProps {
   close: () => void;
@@ -19,10 +20,11 @@ export const SaveAsTemplateModal = ({
   defaultName,
 }: SaveAsTemplateModalProps) => {
   const {
-    mutate: createPrivateTemplate,
+    mutateAsync: createPrivateTemplate,
     isLoading,
     isSuccess,
   } = useCreatePrivateTemplate();
+  const { dopplerLegacyClient } = useAppServices();
   const [templateName, setTemplateName] = useState(defaultName || "");
 
   const successContent = (
@@ -45,13 +47,26 @@ export const SaveAsTemplateModal = ({
     </>
   );
 
-  const saveTemplate = (e: FormEvent<HTMLFormElement>) => {
+  const saveTemplate = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    createPrivateTemplate({
-      ...content,
-      templateName: templateName,
-      isPublic: false,
-    });
+
+    try {
+      const result = await createPrivateTemplate({
+        ...content,
+        templateName: templateName,
+        isPublic: false,
+      });
+
+      if (result.success && result.value?.newTemplateId) {
+        void dopplerLegacyClient
+          .updateTemplateThumbnail(result.value.newTemplateId)
+          .catch((error) => {
+            console.error("Error generating template thumbnail", error);
+          });
+      }
+    } catch (error) {
+      console.error("Error creating private template", error);
+    }
   };
 
   const onChangeName = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
- **Antes,** en el flujo de creacion de campaña, al crear una plantilla desde una campaña, no se generaba el thumbnail:

https://github.com/user-attachments/assets/779625c8-427c-47a3-9d74-d462d1d50852

- **Ahora,** al convertir una campaña en plantilla el flujo crea el template, y **luego dispara la generación del thumbnail** con el id recién creado. La generación del thumbnail **es asíncrona y no bloquea** la confirmación del guardado.

https://github.com/user-attachments/assets/fb0d2820-a53e-4c1c-adbd-cacc8e491b42

