### PR TITLE
Dop 1704 fix thumbnail generation on editor exit 

### DIFF
--- a/src/components/Campaign.test.tsx
+++ b/src/components/Campaign.test.tsx
@@ -20,6 +20,9 @@ jest.mock("./LoadingScreen", () => ({
 }));
 
 const dopplerLegacyBaseUrl = "http://dopplerlegacybaseurl";
+const updateCampaignThumbnail = jest.fn(() =>
+  Promise.resolve({ success: true }),
+);
 const baseAppServices = {
   appSessionStateAccessor: {
     getCurrentSessionState: () => ({
@@ -54,6 +57,8 @@ const baseAppServices = {
           isUnlayerExportHTMLEnabled: true,
         },
       }),
+    updateCampaignThumbnail,
+    updateTemplateThumbnail: jest.fn(() => Promise.resolve({ success: true })),
   },
   editorExtensionsBridge: {
     registerCallbackListener: () => ({ destructor: noop }),
@@ -84,6 +89,11 @@ const windowDouble: any = {
 
 Object.defineProperty(windowDouble.location, "href", {
   set: setHref,
+});
+
+beforeEach(() => {
+  setHref.mockClear();
+  updateCampaignThumbnail.mockClear();
 });
 
 const createTestContext = () => {
@@ -313,6 +323,9 @@ describe(Campaign.name, () => {
 
       // Assert
       expect(updateCampaignContent).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(updateCampaignThumbnail).toHaveBeenCalledWith(idCampaign),
+      );
     },
   );
 
@@ -350,6 +363,9 @@ describe(Campaign.name, () => {
       await userEvent.click(buttonByText);
 
       // Assert
+      await waitFor(() =>
+        expect(updateCampaignThumbnail).toHaveBeenCalledWith(idCampaign),
+      );
       expect(setHref).toHaveBeenCalledWith(urlExpected);
     },
   );
@@ -391,6 +407,9 @@ describe(Campaign.name, () => {
       await userEvent.click(buttonByText);
 
       // Assert
+      await waitFor(() =>
+        expect(updateCampaignThumbnail).toHaveBeenCalledWith(idCampaign),
+      );
       expect(setHref).toHaveBeenCalledWith(urlExpected);
     },
   );
@@ -429,6 +448,9 @@ describe(Campaign.name, () => {
       await userEvent.click(buttonByText);
 
       // Assert
+      await waitFor(() =>
+        expect(updateCampaignThumbnail).toHaveBeenCalledWith("idCampaign"),
+      );
       expect(setHref).toHaveBeenCalledWith(
         baseAppServices.appConfiguration.dopplerExternalUrls.campaigns,
       );

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -48,6 +48,8 @@ export const Campaign = () => {
     smartSave,
     exportContent,
     doWhenNoPendingUpdates,
+    generateThumbnail,
+    skipNextBeforeUnloadThumbnail,
     saveStatus,
     undoTools,
   } = useSingletonEditor({
@@ -109,7 +111,16 @@ export const Campaign = () => {
 
   const saveAndNavigateClick = async (to: string) => {
     smartSave();
-    doWhenNoPendingUpdates(() => navigateSmart(to));
+    doWhenNoPendingUpdates(async () => {
+      try {
+        await generateThumbnail();
+        skipNextBeforeUnloadThumbnail();
+      } catch (error) {
+        window.console.error("Error generating template thumbnail", error);
+      } finally {
+        navigateSmart(to);
+      }
+    });
   };
 
   return (

--- a/src/components/Template.test.tsx
+++ b/src/components/Template.test.tsx
@@ -5,7 +5,7 @@ import { AppServices } from "../abstractions";
 import { HtmlEditorApiClient } from "../abstractions/html-editor-api-client";
 import { AppServicesProvider } from "./AppServicesContext";
 import { TestDopplerIntlProvider } from "./i18n/TestDopplerIntlProvider";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { editorTopBarTestId, errorMessageTestId, Template } from "./Template";
 import { SingletonDesignContextProvider } from "./singleton-editor/singletonDesignContext";
 import { Result } from "../abstractions/common/result-types";
@@ -13,12 +13,19 @@ import { TemplateContent } from "../abstractions/domain/content";
 import { ModalProvider } from "react-modal-hook";
 import { noop } from "../utils";
 import { EditorExtensionsBridge } from "../abstractions/editor-extensions-bridge";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("./LoadingScreen", () => ({
   LoadingScreen: () => <div>Loading...</div>,
 }));
 
 const dopplerLegacyBaseUrl = "http://dopplerlegacybaseurl";
+const updateTemplateThumbnail = jest.fn(() =>
+  Promise.resolve({ success: true }),
+);
+const updateCampaignThumbnail = jest.fn(() =>
+  Promise.resolve({ success: true }),
+);
 const baseAppServices = {
   appConfiguration: {
     unlayerProjectId: 12345,
@@ -42,6 +49,8 @@ const baseAppServices = {
           isUnlayerExportHTMLEnabled: true,
         },
       }),
+    updateTemplateThumbnail,
+    updateCampaignThumbnail,
   },
   editorExtensionsBridge: {
     registerCallbackListener: () => ({ destructor: noop }),
@@ -72,6 +81,12 @@ const windowDouble: any = {
 
 Object.defineProperty(windowDouble.location, "href", {
   set: setHref,
+});
+
+beforeEach(() => {
+  setHref.mockClear();
+  updateTemplateThumbnail.mockClear();
+  updateCampaignThumbnail.mockClear();
 });
 
 const createTestContext = () => {
@@ -254,5 +269,30 @@ describe(Template.name, () => {
     // Assert
     const exportContent = await screen.findByTestId("export-content-btn");
     expect(exportContent).toBeDefined();
+  });
+
+  it("should generate the thumbnail before navigating away", async () => {
+    // Arrange
+    const idTemplate = "1234";
+    const { resolveGetTemplatePromise, TestComponent } = createTestContext();
+
+    renderEditor(<TestComponent routerInitialEntry={`/${idTemplate}`} />);
+    resolveGetTemplatePromise({
+      success: true,
+      value: { type: "unlayer" } as any,
+    });
+
+    const continueButton = await screen.findByText("continue");
+
+    // Act
+    await userEvent.click(continueButton);
+
+    // Assert
+    await waitFor(() =>
+      expect(updateTemplateThumbnail).toHaveBeenCalledWith(idTemplate),
+    );
+    expect(setHref).toHaveBeenCalledWith(
+      baseAppServices.appConfiguration.dopplerExternalUrls.templates,
+    );
   });
 });

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -53,6 +53,8 @@ export const Template = () => {
     smartSave,
     exportContent,
     doWhenNoPendingUpdates,
+    generateThumbnail,
+    skipNextBeforeUnloadThumbnail,
     saveStatus,
     undoTools,
   } = useSingletonEditor({
@@ -86,7 +88,16 @@ export const Template = () => {
 
   const saveAndNavigateClick = async (to: string) => {
     smartSave();
-    doWhenNoPendingUpdates(() => navigateSmart(to));
+    doWhenNoPendingUpdates(async () => {
+      try {
+        await generateThumbnail();
+        skipNextBeforeUnloadThumbnail();
+      } catch (error) {
+        window.console.error("Error generating template thumbnail", error);
+      } finally {
+        navigateSmart(to);
+      }
+    });
   };
 
   if (templateQuery.error) {

--- a/src/components/singleton-editor/useActionWhenNoPendingUpdates.ts
+++ b/src/components/singleton-editor/useActionWhenNoPendingUpdates.ts
@@ -8,7 +8,7 @@ export function useActionWhenNoPendingUpdates({
 }: {
   dispatch: React.Dispatch<Action>;
   areUpdatesPending: boolean;
-  onNoPendingUpdates: null | (() => void);
+  onNoPendingUpdates: null | (() => void | Promise<void>);
 }) {
   // When all pending actions are done
   useEffect(() => {
@@ -18,7 +18,7 @@ export function useActionWhenNoPendingUpdates({
   }, [areUpdatesPending, onNoPendingUpdates]);
 
   const doWhenNoPendingUpdates = useCallback(
-    (action: () => void) => {
+    (action: () => void | Promise<void>) => {
       dispatch({ type: "when-all-saved-action-requested", action });
     },
     [dispatch],

--- a/src/components/singleton-editor/useGenerateThumbnail.ts
+++ b/src/components/singleton-editor/useGenerateThumbnail.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import {
   useUpdateCampaignThumbnail,
@@ -16,15 +16,46 @@ export function useGenerateThumbnail({
 }: {
   global?: Window & typeof globalThis;
 }) {
-  const { mutate: updateTemplateThumbnail } = useUpdateTemplateThumbnail();
-  const { mutate: updateCampaignThumbnail } = useUpdateCampaignThumbnail();
+  const {
+    mutate: updateTemplateThumbnail,
+    mutateAsync: updateTemplateThumbnailAsync,
+  } = useUpdateTemplateThumbnail();
+  const {
+    mutate: updateCampaignThumbnail,
+    mutateAsync: updateCampaignThumbnailAsync,
+  } = useUpdateCampaignThumbnail();
   const { idCampaign, idTemplate } = useParams() as Readonly<{
     idCampaign: string;
     idTemplate: string;
   }>;
+  const skipNextBeforeUnloadThumbnailRef = useRef(false);
+
+  const generateThumbnail = useCallback(async () => {
+    if (idCampaign !== undefined && idCampaign !== "0") {
+      await updateCampaignThumbnailAsync({ idCampaign: idCampaign });
+      return;
+    }
+
+    await updateTemplateThumbnailAsync({ idTemplate: idTemplate });
+  }, [
+    idCampaign,
+    idTemplate,
+    updateCampaignThumbnailAsync,
+    updateTemplateThumbnailAsync,
+  ]);
+
+  const skipNextBeforeUnloadThumbnail = useCallback(() => {
+    skipNextBeforeUnloadThumbnailRef.current = true;
+  }, []);
+
   // When the user exit the editor generate thumbnail
   useEffect(() => {
     const beforeUnloadListener = (e: BeforeUnloadEvent) => {
+      if (skipNextBeforeUnloadThumbnailRef.current) {
+        skipNextBeforeUnloadThumbnailRef.current = false;
+        return;
+      }
+
       if (idCampaign !== undefined && idCampaign !== "0") {
         updateCampaignThumbnail({ idCampaign: idCampaign });
       } else {
@@ -43,7 +74,13 @@ export function useGenerateThumbnail({
     global,
     idCampaign,
     idTemplate,
+    skipNextBeforeUnloadThumbnailRef,
     updateTemplateThumbnail,
     updateCampaignThumbnail,
   ]);
+
+  return {
+    generateThumbnail,
+    skipNextBeforeUnloadThumbnail,
+  };
 }

--- a/src/components/singleton-editor/useSingletonEditor.ts
+++ b/src/components/singleton-editor/useSingletonEditor.ts
@@ -65,7 +65,8 @@ export const useSingletonEditor = ({
     dispatch,
   });
 
-  useGenerateThumbnail({});
+  const { generateThumbnail, skipNextBeforeUnloadThumbnail } =
+    useGenerateThumbnail({});
 
   useContentUpdatesDetection({
     dispatch,
@@ -100,6 +101,8 @@ export const useSingletonEditor = ({
     smartSave,
     exportContent,
     doWhenNoPendingUpdates,
+    generateThumbnail,
+    skipNextBeforeUnloadThumbnail,
     undoTools,
   };
 };


### PR DESCRIPTION
**Actualmente,** al salir del editor luego de presionar en **"Continuar"**, no se estaba esperando la finalizacion del **request para la generacion del thumbnail**, antes de navegar a la seccion de plantillas (`Templates/Main`). 
Esto se hace en el `beforeunload`, y provoca que a veces el browser interrumpa el request o no le de tiempo a completarse.

**Ahora,** se hizo el cambio para mantener el tratamiento en el `beforeunload`, como fallback para los casos que la ventana se cierre "bruscamente", pero ademas se agregó el tratamiento de manera controlada para el caso de "Guarda y salir".

Entonces:
- cuando se presiona en **"Continuar"** -> generacion de thumbnail controlada, esperando que termine (y se saltea el `beforeunload`)
- cuando se cierra "bruscamente" el editor -> generacion de thumbnail como fallback en `beforeunload`